### PR TITLE
Fix NoSuchFileException on offset flush & no function error issues

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -4,6 +4,7 @@ name = "cdc"
 version = "1.3.0"
 distribution = "2201.12.0"
 authors = ["Ballerina"]
+keywords = ["Type/Connector", "Type/Library", "Area/Database", "Vendor/Red Hat", "Debezium"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-cdc"
 license = ["Apache-2.0"]
 

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,12 +5,12 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.13.1"
+distribution-version = "2201.12.0"
 
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.11.0"
+version = "2.9.3"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -34,7 +34,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.13.0"
+version = "1.12.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -142,7 +142,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.17.0"
+version = "2.12.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -156,7 +156,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.7.1"
+version = "1.5.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -187,7 +187,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "sql"
-version = "1.19.0"
+version = "1.16.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -255,7 +255,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "java.jdbc"
-version = "1.15.1"
+version = "1.14.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,12 +5,12 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.12.0"
+distribution-version = "2201.13.1"
 
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.9.3"
+version = "2.11.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -34,7 +34,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.12.0"
+version = "1.13.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -142,7 +142,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.12.0"
+version = "2.17.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -156,7 +156,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.5.1"
+version = "1.7.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -187,7 +187,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "sql"
-version = "1.16.0"
+version = "1.19.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -255,7 +255,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "java.jdbc"
-version = "1.14.1"
+version = "1.15.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -271,7 +271,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "mysql.cdc.driver"
-version = "1.0.1"
+version = "1.0.2"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerinax", name = "mysql.driver"}
@@ -283,6 +283,6 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "mysql.driver"
-version = "1.8.0"
+version = "1.8.1"
 scope = "testOnly"
 

--- a/ballerina/tests/dynamic_attachment.bal
+++ b/ballerina/tests/dynamic_attachment.bal
@@ -14,6 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import ballerina/file;
 import ballerina/test;
 import ballerina/lang.runtime;
 
@@ -215,4 +216,18 @@ function testLivenessWithoutReceivingEvents() returns error? {
     boolean liveness = check isLive(mysqlListener);
     test:assertFalse(liveness, "Liveness check passes even after not receiving events within the liveness interval");
     check mysqlListener.gracefulStop();
+}
+
+@test:Config {}
+function testOffsetStorageParentDirCreation() returns error? {
+    MockListener mysqlListener = new ({
+        database: {username, password, port},
+        options: {snapshotMode: NO_DATA},
+        offsetStorage: {fileName: "tmp/nested/offsets.dat"}
+    });
+    check mysqlListener.attach(testService);
+    check mysqlListener.'start();
+    test:assertTrue(check file:test("tmp/nested", file:EXISTS),
+            msg = "Parent directory for offset storage file was not created.");
+    check mysqlListener.immediateStop();
 }

--- a/ballerina/tests/listener_tests.bal
+++ b/ballerina/tests/listener_tests.bal
@@ -112,7 +112,7 @@ function testMockListenerEvents() returns error? {
         `INSERT INTO vendors (id, name, contact_info) 
         VALUES (201, 'Vendor A', 'contact@vendora.com')`);
     runtime:sleep(3);
-    test:assertEquals(onErrorCount, 3, msg = "Error count mismatch.");
+    test:assertEquals(onErrorCount, 1, msg = "Error count mismatch.");
     // 1,2 for onRead method not present, 3 for payload binding failure
 
     check testListener.gracefulStop();

--- a/ballerina/tests/listener_tests.bal
+++ b/ballerina/tests/listener_tests.bal
@@ -112,8 +112,8 @@ function testMockListenerEvents() returns error? {
         `INSERT INTO vendors (id, name, contact_info) 
         VALUES (201, 'Vendor A', 'contact@vendora.com')`);
     runtime:sleep(3);
+    // Missing onRead on vendors triggers a warning, not an error — only the binding failure reaches onError
     test:assertEquals(onErrorCount, 1, msg = "Error count mismatch.");
-    // 1,2 for onRead method not present, 3 for payload binding failure
 
     check testListener.gracefulStop();
 }

--- a/native/src/main/java/io/ballerina/lib/cdc/BalChangeConsumer.java
+++ b/native/src/main/java/io/ballerina/lib/cdc/BalChangeConsumer.java
@@ -41,6 +41,7 @@ import io.ballerina.runtime.api.values.BTypedesc;
 import io.debezium.engine.ChangeEvent;
 import io.debezium.engine.DebeziumEngine;
 
+import java.io.PrintStream;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -67,6 +68,7 @@ import static java.lang.Boolean.FALSE;
  * Handles change events from the Debezium engine and invokes the appropriate Ballerina service methods.
  */
 public class BalChangeConsumer implements DebeziumEngine.ChangeConsumer<ChangeEvent<String, String>> {
+    private static final PrintStream ERR_OUT = System.err;
 
     private final Map<String, Service> serviceMap;
     private final boolean isSingleServiceAttached;
@@ -214,7 +216,7 @@ public class BalChangeConsumer implements DebeziumEngine.ChangeConsumer<ChangeEv
                         ServiceMethodNames.ON_ERROR, metaData, bError);
                 handleReturnValue(returnValue);
             } else {
-                bError.printStackTrace();
+                ERR_OUT.println("warning: " + bError.getPrintableStackTrace());
             }
         } catch (BError balError) {
             balError.printStackTrace();

--- a/native/src/main/java/io/ballerina/lib/cdc/BalChangeConsumer.java
+++ b/native/src/main/java/io/ballerina/lib/cdc/BalChangeConsumer.java
@@ -109,7 +109,9 @@ public class BalChangeConsumer implements DebeziumEngine.ChangeConsumer<ChangeEv
                 String methodName = getMethodName(payload.getOp());
                 Method method = selectedService.getMethod(methodName);
                 if (method == null) {
-                    throw createMethodNotFoundError(payload, methodName);
+                    ERR_OUT.println("warning: Function '" + methodName + "' is not available.");
+                    committer.markProcessed(record);
+                    continue;
                 }
 
                 boolean isIsolated = selectedService.isIsolated() && method.isIsolated();
@@ -169,10 +171,6 @@ public class BalChangeConsumer implements DebeziumEngine.ChangeConsumer<ChangeEv
 
     private Object[] processParameters(Service service, String functionName, Payload payload) {
         Method method = service.getMethod(functionName);
-        if (method == null) {
-            throw createMethodNotFoundError(payload, functionName);
-        }
-
         List<Object> parameters = new ArrayList<>();
         if (method.hasBeforeParam()) {
             parameters.add(processParameterToIntendedType(payload, EventMembers.BEFORE, method.beforeParamType()));
@@ -216,7 +214,7 @@ public class BalChangeConsumer implements DebeziumEngine.ChangeConsumer<ChangeEv
                         ServiceMethodNames.ON_ERROR, metaData, bError);
                 handleReturnValue(returnValue);
             } else {
-                ERR_OUT.println("warning: " + bError.getPrintableStackTrace());
+                bError.printStackTrace();
             }
         } catch (BError balError) {
             balError.printStackTrace();
@@ -228,12 +226,6 @@ public class BalChangeConsumer implements DebeziumEngine.ChangeConsumer<ChangeEv
         if (returnValue instanceof BError) {
             ((BError) returnValue).printStackTrace();
         }
-    }
-
-    private BError createMethodNotFoundError(Payload payload, String methodName) {
-        BMap<BString, Object> detail = getEventProcessingErrorDetail(payload.toString());
-        return createError(EVENT_PROCESSING_ERROR, "Function '" + methodName + "' is not available.",
-                null, ValueCreator.createRecordValue(getModule(), EVENT_PROCESSING_ERROR_DETAIL, detail));
     }
 
     private boolean isHeartbeatEvent(ChangeEvent<String, String> record) {

--- a/native/src/main/java/io/ballerina/lib/cdc/Listener.java
+++ b/native/src/main/java/io/ballerina/lib/cdc/Listener.java
@@ -11,7 +11,7 @@
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express q or implied. See the License for the
+ * KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations
  * under the License.
  */
@@ -36,6 +36,9 @@ import io.debezium.engine.format.Json;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Map;
@@ -227,6 +230,8 @@ public class Listener {
 
     private static Object startEngine(Environment environment, BObject listener, Properties engineProperties,
                                       Long livenessInterval) throws Exception {
+        createParentDirectoriesIfNeeded(engineProperties);
+
         @SuppressWarnings("unchecked")
         ConcurrentHashMap<String, Service> serviceMap = (ConcurrentHashMap<String, Service>) listener
                 .getNativeData(TABLE_TO_SERVICE_MAP_KEY);
@@ -365,6 +370,22 @@ public class Listener {
             return createCdcError("Failed to invoke the liveliness check for the Debezium engine: " + e.getMessage());
         } finally {
             lock.unlock();
+        }
+    }
+
+    private static void createParentDirectoriesIfNeeded(Properties engineProperties) throws IOException {
+        String[] fileProps = {
+                "offset.storage.file.filename",
+                "schema.history.internal.file.filename"
+        };
+        for (String prop : fileProps) {
+            String filePath = engineProperties.getProperty(prop);
+            if (filePath != null) {
+                Path parent = Paths.get(filePath).getParent();
+                if (parent != null) {
+                    Files.createDirectories(parent);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Root cause

Kafka Connect's `FileOffsetBackingStore` calls `Files.newOutputStream(path)` directly without creating parent directories first. For connectors that use schema history (e.g. MSSQL, MySQL), this is masked: `FileSchemaHistory.start()` calls `Files.createDirectories()` on the schema history file's parent as a side effect, so the `tmp/` directory already exists by the time the first offset flush occurs.

PostgreSQL uses WAL-based logical replication and does **not** use `FileSchemaHistory`. Nothing creates the parent directory, so every call to `committer.markBatchFinished()` triggers an offset flush that fails with:

```
SEVERE: Flush of EmbeddedEngine offsets threw an unexpected exception:
java.util.concurrent.ExecutionException: org.apache.kafka.connect.errors.ConnectException:
    java.nio.file.NoSuchFileException: tmp/debezium-offsets.dat
```

The exception is caught and swallowed by the embedded engine (logged at SEVERE, not propagated to Ballerina), so the failure is silent from the user's perspective — but offsets are never persisted, causing the connector to re-read from the beginning of the WAL on every restart.

Additionally, when a CDC service omits a handler (e.g. `onRead`), the module was throwing a `BError` that propagated through `handleError()` and landed at `bError.printStackTrace()` — printing a full `error:` line with the entire event payload to stderr on every captured event.

## Fix

Create parent directories for `offset.storage.file.filename` and `schema.history.internal.file.filename` before starting the Debezium engine in `Listener.startEngine()`.

For missing service methods, replace the `BError` throw with a one-line `warning:` to stderr, then skip the event. The event payload is excluded from the warning to keep output concise.

## References

Fixes https://github.com/wso2/product-integrator/issues/942

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This pull request improves stability and error handling in the Debezium-based CDC connector module by addressing two runtime issues.

### Main changes
- Listener startup: Ensure parent directories exist for configured offset storage and schema history files before starting the Debezium engine. This prevents failures when those directories are missing and ensures offsets are persisted across restarts.
- Handler missing behavior: Replace thrown errors for missing CDC service handler methods with concise stderr warnings and skip processing of the affected event, avoiding verbose stack traces that previously included full event payloads.
- Metadata and dependencies: Add package classification keywords to Ballerina.toml and bump test-only dependency versions in Dependencies.toml.
- Tests: Add a test verifying creation of nested offset storage directories and update an existing test to reflect the changed behavior for missing handlers.

### Outcomes
- Improved reliability of offset persistence and connector restarts.
- Cleaner, less noisy error handling when service handlers are absent while retaining diagnostic visibility.
- Minor package metadata and test dependency updates.

Reference: https://github.com/wso2/product-integrator/issues/942
<!-- end of auto-generated comment: release notes by coderabbit.ai -->