### PR TITLE
Fix CVE-2026-35554: upgrade kafka-clients 3.9.1 → 3.9.2

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -95,26 +95,26 @@ path = "./lib/jctools-core-4.0.5.jar"
 [[platform.java21.dependency]]
 groupId = "org.apache.kafka"
 artifactId = "kafka-clients"
-version = "3.9.2"
-path = "./lib/kafka-clients-3.9.2.jar"
+version = "3.9.1"
+path = "./lib/kafka-clients-3.9.1.jar"
 
 [[platform.java21.dependency]]
 groupId = "org.apache.kafka"
 artifactId = "connect-api"
-version = "3.9.2"
-path = "./lib/connect-api-3.9.2.jar"
+version = "3.9.1"
+path = "./lib/connect-api-3.9.1.jar"
 
 [[platform.java21.dependency]]
 groupId = "org.apache.kafka"
 artifactId = "connect-json"
-version = "3.9.2"
-path = "./lib/connect-json-3.9.2.jar"
+version = "3.9.1"
+path = "./lib/connect-json-3.9.1.jar"
 
 [[platform.java21.dependency]]
 groupId = "org.apache.kafka"
 artifactId = "connect-runtime"
-version = "3.9.2"
-path = "./lib/connect-runtime-3.9.2.jar"
+version = "3.9.1"
+path = "./lib/connect-runtime-3.9.1.jar"
 
 [[platform.java21.dependency]]
 groupId = "com.fasterxml.jackson.core"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "cdc"
-version = "1.3.0"
+version = "1.3.1"
 distribution = "2201.12.0"
 authors = ["Ballerina"]
 keywords = ["Type/Connector", "Type/Library", "Area/Database", "Vendor/Red Hat", "Debezium"]
@@ -16,9 +16,9 @@ graalvmCompatible=true
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.lib.cdc"
-artifactId = "cdc-native-1.3.0"
-version = "1.3.0"
-path = "../native/build/libs/cdc-native-1.3.0.jar"
+artifactId = "cdc-native-1.3.1-SNAPSHOT"
+version = "1.3.1-SNAPSHOT"
+path = "../native/build/libs/cdc-native-1.3.1-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.debezium"
@@ -95,26 +95,26 @@ path = "./lib/jctools-core-4.0.5.jar"
 [[platform.java21.dependency]]
 groupId = "org.apache.kafka"
 artifactId = "kafka-clients"
-version = "3.9.1"
-path = "./lib/kafka-clients-3.9.1.jar"
+version = "3.9.2"
+path = "./lib/kafka-clients-3.9.2.jar"
 
 [[platform.java21.dependency]]
 groupId = "org.apache.kafka"
 artifactId = "connect-api"
-version = "3.9.1"
-path = "./lib/connect-api-3.9.1.jar"
+version = "3.9.2"
+path = "./lib/connect-api-3.9.2.jar"
 
 [[platform.java21.dependency]]
 groupId = "org.apache.kafka"
 artifactId = "connect-json"
-version = "3.9.1"
-path = "./lib/connect-json-3.9.1.jar"
+version = "3.9.2"
+path = "./lib/connect-json-3.9.2.jar"
 
 [[platform.java21.dependency]]
 groupId = "org.apache.kafka"
 artifactId = "connect-runtime"
-version = "3.9.1"
-path = "./lib/connect-runtime-3.9.1.jar"
+version = "3.9.2"
+path = "./lib/connect-runtime-3.9.2.jar"
 
 [[platform.java21.dependency]]
 groupId = "com.fasterxml.jackson.core"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -95,26 +95,26 @@ path = "./lib/jctools-core-4.0.5.jar"
 [[platform.java21.dependency]]
 groupId = "org.apache.kafka"
 artifactId = "kafka-clients"
-version = "3.9.1"
-path = "./lib/kafka-clients-3.9.1.jar"
+version = "3.9.2"
+path = "./lib/kafka-clients-3.9.2.jar"
 
 [[platform.java21.dependency]]
 groupId = "org.apache.kafka"
 artifactId = "connect-api"
-version = "3.9.1"
-path = "./lib/connect-api-3.9.1.jar"
+version = "3.9.2"
+path = "./lib/connect-api-3.9.2.jar"
 
 [[platform.java21.dependency]]
 groupId = "org.apache.kafka"
 artifactId = "connect-json"
-version = "3.9.1"
-path = "./lib/connect-json-3.9.1.jar"
+version = "3.9.2"
+path = "./lib/connect-json-3.9.2.jar"
 
 [[platform.java21.dependency]]
 groupId = "org.apache.kafka"
 artifactId = "connect-runtime"
-version = "3.9.1"
-path = "./lib/connect-runtime-3.9.1.jar"
+version = "3.9.2"
+path = "./lib/connect-runtime-3.9.2.jar"
 
 [[platform.java21.dependency]]
 groupId = "com.fasterxml.jackson.core"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "cdc-compiler-plugin"
 class = "io.ballerina.lib.cdc.compiler.CdcCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/cdc-compiler-plugin-1.3.0.jar"
+path = "../compiler-plugin/build/libs/cdc-compiler-plugin-1.3.1-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,12 +5,12 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.12.0"
+distribution-version = "2201.13.1"
 
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.9.3"
+version = "2.11.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -34,7 +34,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.12.0"
+version = "1.13.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -142,7 +142,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.12.0"
+version = "2.17.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -156,7 +156,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.5.1"
+version = "1.7.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -187,7 +187,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "sql"
-version = "1.16.0"
+version = "1.19.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -233,7 +233,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "cdc"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "data.jsondata"},
@@ -255,7 +255,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "java.jdbc"
-version = "1.14.1"
+version = "1.15.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,12 +5,12 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.13.1"
+distribution-version = "2201.12.0"
 
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.11.0"
+version = "2.9.3"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -34,7 +34,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.13.0"
+version = "1.12.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -142,7 +142,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.17.0"
+version = "2.12.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -156,7 +156,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.7.1"
+version = "1.5.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -187,7 +187,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "sql"
-version = "1.19.0"
+version = "1.16.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -255,7 +255,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "java.jdbc"
-version = "1.15.1"
+version = "1.14.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ ballerinaGradlePluginVersion=2.3.1
 testngVersion=7.6.1
 
 debeziumVersion=3.0.8.Final
-kafkaVersion=3.9.1
+kafkaVersion=3.9.2
 # This ver should be the one packed with debezium
 fasterxmlVersion=2.18.6
 gsonVersion=2.10.1


### PR DESCRIPTION
## Summary

- Bumps `kafkaVersion` from `3.9.1` to `3.9.2` in `gradle.properties` to fix **CVE-2026-35554** (HIGH — information disclosure and data corruption in Apache Kafka Clients)
- Affects all four kafka artifacts managed by this property: `kafka-clients`, `connect-api`, `connect-json`, `connect-runtime`
- `ballerina/Ballerina.toml` auto-regenerated by the Gradle `updateTomlFiles`/`commitTomlFiles` tasks

## Test plan

- [x] `./gradlew :cdc-ballerina:dependencies --configuration externalJars` — all four kafka artifacts resolve clean at 3.9.2 (no upgrade arrows)
- [x] `./gradlew build` — BUILD SUCCESSFUL
- [x] Confirmed test failures are identical to baseline (pre-existing Ballerina compilation issues unrelated to this change)
- [ ] Re-run vulnerability scanner on rebuilt `ballerina/lib/` to confirm CVE-2026-35554 is cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request updates the Apache Kafka client library dependency from version 3.9.1 to 3.9.2, along with related Ballerina package and dependency version updates.

### Changes

**gradle.properties:**
- Updated `kafkaVersion` from 3.9.1 to 3.9.2, which affects the resolution of four Kafka artifacts: `kafka-clients`, `connect-api`, `connect-json`, and `connect-runtime`

**Ballerina package and dependencies:**
- Bumped the CDC module package version from 1.3.0 to 1.3.1 in `ballerina/Ballerina.toml`
- Updated the Java21 platform dependency reference and compiler plugin path to align with the new 1.3.1-SNAPSHOT artifact version
- Updated the Ballerina distribution version from 2201.12.0 to 2201.13.1 in `ballerina/Dependencies.toml`
- Upgraded several transitive dependencies: `crypto`, `file`, `log`, `observe`, `sql`, and `java.jdbc` packages

### Testing

Build verification completed successfully. All four Kafka artifacts resolve at version 3.9.2. Pre-existing Ballerina compilation issues remain unrelated to this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->