### PR TITLE
Fix liveness check to report not-live immediately after listener stop

### DIFF
--- a/native/src/main/java/io/ballerina/lib/cdc/Listener.java
+++ b/native/src/main/java/io/ballerina/lib/cdc/Listener.java
@@ -326,6 +326,12 @@ public class Listener {
 
         lock.lock();
         try {
+            Object isStartedObj = listener.getNativeData(IS_STARTED_KEY);
+            boolean isStarted = isStartedObj != null && ((Boolean) isStartedObj);
+            if (!isStarted) {
+                return false;
+            }
+
             Object completionCallback = listener.getNativeData(COMP_CALLBACK_KEY);
             if (completionCallback != null) {
                 boolean invoked = ((CdcCompletionCallback) completionCallback).isInvoked();


### PR DESCRIPTION
## Purpose

`isLive()` could still report a listener as **live** immediately after `gracefulStop()`/`immediateStop()`, causing intermittent failures (e.g. `testLivenessAfterListenerStop` in connector test suites — fails reliably under slower CI).

## Root cause

`isLive()` detected a stopped listener only via the Debezium completion callback (`CdcCompletionCallback.isInvoked()`). That callback fires **asynchronously** on the engine thread once shutdown actually completes. Neither `engine.close()` nor `executor.shutdown()` waits for it, so right after a stop call returns the callback often hasn't run yet. `isLive()` then fell through to the "still within the liveness interval" check (default 60s) and returned `true`.

This is timing-dependent: when the callback happens to fire first the check passes, hence the intermittent / environment-dependent failures.

## Fix

Short-circuit `isLive()` on the synchronously-set `IS_STARTED` flag. `gracefulStop()`/`immediateStop()` already set `IS_STARTED = false` under the per-listener lock before returning, so a deliberately stopped listener is now reported not-live **deterministically**, independent of when the async completion callback runs. The callback check still covers unexpected engine death while the listener is running.

```java
Object isStartedObj = listener.getNativeData(IS_STARTED_KEY);
boolean isStarted = isStartedObj != null && ((Boolean) isStartedObj);
if (!isStarted) {
    return false;
}
```

## Checks

- [x] `:cdc-native:compileJava` passes
- [ ] Full build / liveness tests (draft — CI to verify)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request fixes an intermittent stability issue in the CDC module's liveness check where `isLive()` would incorrectly report a listener as active immediately after being stopped.

## Problem

The `isLive()` method relied on an asynchronous Debezium completion callback to detect when a listener was shut down. However, this callback executes on the engine thread independent of when the stop operation completes. As a result, `isLive()` could be called before the callback executed, causing it to fall back to a time-based check (default liveness interval of 60 seconds) and incorrectly return `true`. This timing-dependent behavior led to unreliable test failures, particularly in slower CI environments.

## Solution

The fix introduces an early synchronous check on the `IS_STARTED` flag in the `isLive()` method. Since `gracefulStop()` and `immediateStop()` already set `IS_STARTED = false` under a per-listener lock before returning, a stopped listener is now deterministically reported as not-live, independent of when the asynchronous completion callback executes. The callback check remains in place to detect unexpected engine failures while the listener is running.

## Changes

- Modified `Listener.isLive()` to check the listener's `isStarted` flag at the start of the liveness evaluation and immediately return `false` when the listener is not started, before proceeding to completion-callback and liveness-interval checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->