### PR TITLE
Bump Debezium to 3.5.1.Final; fix startup/shutdown robustness

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "cdc"
-version = "1.3.1"
+version = "1.4.0"
 distribution = "2201.12.0"
 authors = ["Ballerina"]
 keywords = ["Type/Connector", "Type/Library", "Area/Database", "Vendor/Red Hat", "Debezium"]
@@ -16,75 +16,96 @@ graalvmCompatible=true
 
 [[platform.java21.dependency]]
 groupId = "io.ballerina.lib.cdc"
-artifactId = "cdc-native-1.3.1"
-version = "1.3.1"
-path = "../native/build/libs/cdc-native-1.3.1.jar"
+artifactId = "cdc-native-1.4.0-SNAPSHOT"
+version = "1.4.0-SNAPSHOT"
+path = "../native/build/libs/cdc-native-1.4.0-SNAPSHOT.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.debezium"
 artifactId = "debezium-api"
-version = "3.0.8.Final"
-path = "./lib/debezium-api-3.0.8.Final.jar"
+version = "3.5.1.Final"
+path = "./lib/debezium-api-3.5.1.Final.jar"
+
+# Debezium 3.5 turned debezium-core into a pom-only aggregator (no jar). The classes that
+# used to live inside debezium-core in 3.0.x are now split across the modules below, which
+# are required at runtime.
+[[platform.java21.dependency]]
+groupId = "io.debezium"
+artifactId = "debezium-config"
+version = "3.5.1.Final"
+path = "./lib/debezium-config-3.5.1.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.debezium"
-artifactId = "debezium-core"
-version = "3.0.8.Final"
-path = "./lib/debezium-core-3.0.8.Final.jar"
+artifactId = "debezium-util"
+version = "3.5.1.Final"
+path = "./lib/debezium-util-3.5.1.Final.jar"
+
+[[platform.java21.dependency]]
+groupId = "io.debezium"
+artifactId = "debezium-connector-common"
+version = "3.5.1.Final"
+path = "./lib/debezium-connector-common-3.5.1.Final.jar"
+
+[[platform.java21.dependency]]
+groupId = "io.debezium"
+artifactId = "debezium-openlineage-api"
+version = "3.5.1.Final"
+path = "./lib/debezium-openlineage-api-3.5.1.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.debezium"
 artifactId = "debezium-embedded"
-version = "3.0.8.Final"
-path = "./lib/debezium-embedded-3.0.8.Final.jar"
+version = "3.5.1.Final"
+path = "./lib/debezium-embedded-3.5.1.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.debezium"
 artifactId = "debezium-storage-file"
-version = "3.0.8.Final"
-path = "./lib/debezium-storage-file-3.0.8.Final.jar"
+version = "3.5.1.Final"
+path = "./lib/debezium-storage-file-3.5.1.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.debezium"
 artifactId = "debezium-storage-kafka"
-version = "3.0.8.Final"
-path = "./lib/debezium-storage-kafka-3.0.8.Final.jar"
+version = "3.5.1.Final"
+path = "./lib/debezium-storage-kafka-3.5.1.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.debezium"
 artifactId = "debezium-storage-redis"
-version = "3.0.8.Final"
-path = "./lib/debezium-storage-redis-3.0.8.Final.jar"
+version = "3.5.1.Final"
+path = "./lib/debezium-storage-redis-3.5.1.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.debezium"
 artifactId = "debezium-storage-jdbc"
-version = "3.0.8.Final"
-path = "./lib/debezium-storage-jdbc-3.0.8.Final.jar"
+version = "3.5.1.Final"
+path = "./lib/debezium-storage-jdbc-3.5.1.Final.jar"
 
 [[platform.java21.dependency]]
 groupId = "redis.clients"
 artifactId = "jedis"
-version = "4.1.1"
-path = "./lib/jedis-4.1.1.jar"
+version = "6.0.0"
+path = "./lib/jedis-6.0.0.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.smallrye.reactive"
 artifactId = "mutiny"
-version = "2.6.2"
-path = "./lib/mutiny-2.6.2.jar"
+version = "2.9.5"
+path = "./lib/mutiny-2.9.5.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.smallrye.common"
 artifactId = "smallrye-common-annotation"
-version = "2.5.0"
-path = "./lib/smallrye-common-annotation-2.5.0.jar"
+version = "2.13.9"
+path = "./lib/smallrye-common-annotation-2.13.9.jar"
 
 [[platform.java21.dependency]]
 groupId = "org.apache.commons"
 artifactId = "commons-pool2"
-version = "2.11.1"
-path = "./lib/commons-pool2-2.11.1.jar"
+version = "2.12.1"
+path = "./lib/commons-pool2-2.12.1.jar"
 
 [[platform.java21.dependency]]
 groupId = "org.jctools"
@@ -95,47 +116,74 @@ path = "./lib/jctools-core-4.0.5.jar"
 [[platform.java21.dependency]]
 groupId = "org.apache.kafka"
 artifactId = "kafka-clients"
-version = "3.9.2"
-path = "./lib/kafka-clients-3.9.2.jar"
+version = "4.1.1"
+path = "./lib/kafka-clients-4.1.1.jar"
 
 [[platform.java21.dependency]]
 groupId = "org.apache.kafka"
 artifactId = "connect-api"
-version = "3.9.2"
-path = "./lib/connect-api-3.9.2.jar"
+version = "4.1.1"
+path = "./lib/connect-api-4.1.1.jar"
 
 [[platform.java21.dependency]]
 groupId = "org.apache.kafka"
 artifactId = "connect-json"
-version = "3.9.2"
-path = "./lib/connect-json-3.9.2.jar"
+version = "4.1.1"
+path = "./lib/connect-json-4.1.1.jar"
 
 [[platform.java21.dependency]]
 groupId = "org.apache.kafka"
 artifactId = "connect-runtime"
-version = "3.9.2"
-path = "./lib/connect-runtime-3.9.2.jar"
+version = "4.1.1"
+path = "./lib/connect-runtime-4.1.1.jar"
+
+# Required at runtime by connect-runtime for connector version comparison (ComparableVersion).
+[[platform.java21.dependency]]
+groupId = "org.apache.maven"
+artifactId = "maven-artifact"
+version = "3.9.6"
+path = "./lib/maven-artifact-3.9.6.jar"
+
+# Kafka 4.x compression codecs required at runtime by kafka-clients/connect.
+[[platform.java21.dependency]]
+groupId = "org.lz4"
+artifactId = "lz4-java"
+version = "1.8.0"
+path = "./lib/lz4-java-1.8.0.jar"
+
+[[platform.java21.dependency]]
+groupId = "org.xerial.snappy"
+artifactId = "snappy-java"
+version = "1.1.10.7"
+path = "./lib/snappy-java-1.1.10.7.jar"
+
+[[platform.java21.dependency]]
+groupId = "com.github.luben"
+artifactId = "zstd-jni"
+version = "1.5.6-10"
+path = "./lib/zstd-jni-1.5.6-10.jar"
 
 [[platform.java21.dependency]]
 groupId = "com.fasterxml.jackson.core"
 artifactId = "jackson-core"
-version = "2.18.6"
-path = "./lib/jackson-core-2.18.6.jar"
+version = "2.19.0"
+path = "./lib/jackson-core-2.19.0.jar"
 
+# Debezium/Jackson 2.19 replaced the deprecated afterburner module with blackbird.
 [[platform.java21.dependency]]
 groupId = "com.fasterxml.jackson.module"
-artifactId = "jackson-module-afterburner"
-version = "2.18.6"
-path = "./lib/jackson-module-afterburner-2.18.6.jar"
+artifactId = "jackson-module-blackbird"
+version = "2.19.0"
+path = "./lib/jackson-module-blackbird-2.19.0.jar"
 
 [[platform.java21.dependency]]
 groupId = "com.fasterxml.jackson.core"
 artifactId = "jackson-annotations"
-version = "2.18.6"
-path = "./lib/jackson-annotations-2.18.6.jar"
+version = "2.19.0"
+path = "./lib/jackson-annotations-2.19.0.jar"
 
 [[platform.java21.dependency]]
 groupId = "com.fasterxml.jackson.core"
 artifactId = "jackson-databind"
-version = "2.18.6"
-path = "./lib/jackson-databind-2.18.6.jar"
+version = "2.19.0"
+path = "./lib/jackson-databind-2.19.0.jar"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -11,26 +11,6 @@ license = ["Apache-2.0"]
 [build-options]
 observabilityIncluded = true
 
-# Temporary local dependencies used by the schema-history integration tests.
-# Replace these with Central dependencies when the matching driver releases are published.
-[[dependency]]
-org = "ballerinax"
-name = "cdc.schema.azure.blob.driver"
-version = "1.1.0"
-repository = "local"
-
-[[dependency]]
-org = "ballerinax"
-name = "cdc.schema.aws.s3.driver"
-version = "1.1.0"
-repository = "local"
-
-[[dependency]]
-org = "ballerinax"
-name = "cdc.schema.rocketmq.driver"
-version = "1.1.0"
-repository = "local"
-
 [platform.java21]
 graalvmCompatible=true
 
@@ -133,26 +113,26 @@ path = "./lib/jctools-core-4.0.5.jar"
 [[platform.java21.dependency]]
 groupId = "org.apache.kafka"
 artifactId = "kafka-clients"
-version = "4.1.1"
-path = "./lib/kafka-clients-4.1.1.jar"
+version = "4.1.2"
+path = "./lib/kafka-clients-4.1.2.jar"
 
 [[platform.java21.dependency]]
 groupId = "org.apache.kafka"
 artifactId = "connect-api"
-version = "4.1.1"
-path = "./lib/connect-api-4.1.1.jar"
+version = "4.1.2"
+path = "./lib/connect-api-4.1.2.jar"
 
 [[platform.java21.dependency]]
 groupId = "org.apache.kafka"
 artifactId = "connect-json"
-version = "4.1.1"
-path = "./lib/connect-json-4.1.1.jar"
+version = "4.1.2"
+path = "./lib/connect-json-4.1.2.jar"
 
 [[platform.java21.dependency]]
 groupId = "org.apache.kafka"
 artifactId = "connect-runtime"
-version = "4.1.1"
-path = "./lib/connect-runtime-4.1.1.jar"
+version = "4.1.2"
+path = "./lib/connect-runtime-4.1.2.jar"
 
 # Required at runtime by connect-runtime for connector version comparison (ComparableVersion).
 [[platform.java21.dependency]]
@@ -163,10 +143,10 @@ path = "./lib/maven-artifact-3.9.6.jar"
 
 # Kafka 4.x compression codecs required at runtime by kafka-clients/connect.
 [[platform.java21.dependency]]
-groupId = "org.lz4"
+groupId = "at.yawk.lz4"
 artifactId = "lz4-java"
-version = "1.8.0"
-path = "./lib/lz4-java-1.8.0.jar"
+version = "1.10.1"
+path = "./lib/lz4-java-1.10.1.jar"
 
 [[platform.java21.dependency]]
 groupId = "org.xerial.snappy"
@@ -183,24 +163,24 @@ path = "./lib/zstd-jni-1.5.6-10.jar"
 [[platform.java21.dependency]]
 groupId = "com.fasterxml.jackson.core"
 artifactId = "jackson-core"
-version = "2.19.0"
-path = "./lib/jackson-core-2.19.0.jar"
+version = "2.21.4"
+path = "./lib/jackson-core-2.21.4.jar"
 
 # Debezium/Jackson 2.19 replaced the deprecated afterburner module with blackbird.
 [[platform.java21.dependency]]
 groupId = "com.fasterxml.jackson.module"
 artifactId = "jackson-module-blackbird"
-version = "2.19.0"
-path = "./lib/jackson-module-blackbird-2.19.0.jar"
+version = "2.21.4"
+path = "./lib/jackson-module-blackbird-2.21.4.jar"
 
 [[platform.java21.dependency]]
 groupId = "com.fasterxml.jackson.core"
 artifactId = "jackson-annotations"
-version = "2.19.0"
-path = "./lib/jackson-annotations-2.19.0.jar"
+version = "2.21"
+path = "./lib/jackson-annotations-2.21.jar"
 
 [[platform.java21.dependency]]
 groupId = "com.fasterxml.jackson.core"
 artifactId = "jackson-databind"
-version = "2.19.0"
-path = "./lib/jackson-databind-2.19.0.jar"
+version = "2.21.4"
+path = "./lib/jackson-databind-2.21.4.jar"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -11,6 +11,26 @@ license = ["Apache-2.0"]
 [build-options]
 observabilityIncluded = true
 
+# Temporary local dependencies used by the schema-history integration tests.
+# Replace these with Central dependencies when the matching driver releases are published.
+[[dependency]]
+org = "ballerinax"
+name = "cdc.schema.azure.blob.driver"
+version = "1.1.0"
+repository = "local"
+
+[[dependency]]
+org = "ballerinax"
+name = "cdc.schema.aws.s3.driver"
+version = "1.1.0"
+repository = "local"
+
+[[dependency]]
+org = "ballerinax"
+name = "cdc.schema.rocketmq.driver"
+version = "1.1.0"
+repository = "local"
+
 [platform.java21]
 graalvmCompatible=true
 

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -2,7 +2,7 @@
 org = "ballerinax"
 name = "cdc"
 version = "1.4.0"
-distribution = "2201.13.0"
+distribution = "2201.12.0"
 authors = ["Ballerina"]
 keywords = ["Type/Connector", "Type/Library", "Area/Database", "Vendor/Red Hat", "Debezium"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-cdc"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -26,9 +26,6 @@ artifactId = "debezium-api"
 version = "3.5.1.Final"
 path = "./lib/debezium-api-3.5.1.Final.jar"
 
-# Debezium 3.5 turned debezium-core into a pom-only aggregator (no jar). The classes that
-# used to live inside debezium-core in 3.0.x are now split across the modules below, which
-# are required at runtime.
 [[platform.java21.dependency]]
 groupId = "io.debezium"
 artifactId = "debezium-config"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -2,7 +2,7 @@
 org = "ballerinax"
 name = "cdc"
 version = "1.4.0"
-distribution = "2201.12.0"
+distribution = "2201.13.0"
 authors = ["Ballerina"]
 keywords = ["Type/Connector", "Type/Library", "Area/Database", "Vendor/Red Hat", "Debezium"]
 repository = "https://github.com/ballerina-platform/module-ballerinax-cdc"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "cdc-compiler-plugin"
 class = "io.ballerina.lib.cdc.compiler.CdcCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/cdc-compiler-plugin-1.3.1.jar"
+path = "../compiler-plugin/build/libs/cdc-compiler-plugin-1.4.0-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.12.0"
+distribution-version = "2201.13.0"
 
 [[package]]
 org = "ballerina"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.13.0"
+distribution-version = "2201.13.4"
 
 [[package]]
 org = "ballerina"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.13.0"
+distribution-version = "2201.12.0"
 
 [[package]]
 org = "ballerina"
@@ -22,7 +22,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "data.jsondata"
-version = "1.1.3"
+version = "1.1.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.object"}
@@ -142,7 +142,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.17.0"
+version = "2.14.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -156,7 +156,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.7.1"
+version = "1.5.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -187,7 +187,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "sql"
-version = "1.19.0"
+version = "1.16.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -213,7 +213,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.8.1"
+version = "2.7.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -285,7 +285,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "java.jdbc"
-version = "1.15.1"
+version = "1.14.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.13.4"
+distribution-version = "2201.12.0"
 
 [[package]]
 org = "ballerina"
@@ -22,7 +22,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "data.jsondata"
-version = "1.1.3"
+version = "1.1.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.object"}
@@ -142,7 +142,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.17.0"
+version = "2.14.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -156,7 +156,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.7.1"
+version = "1.5.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -187,7 +187,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "sql"
-version = "1.19.0"
+version = "1.16.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -213,7 +213,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.8.1"
+version = "2.7.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -285,7 +285,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "java.jdbc"
-version = "1.15.1"
+version = "1.14.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.13.0"
+distribution-version = "2201.12.0"
 
 [[package]]
 org = "ballerina"
@@ -22,7 +22,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "data.jsondata"
-version = "1.1.3"
+version = "1.1.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.object"}
@@ -142,7 +142,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.17.0"
+version = "2.14.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -156,7 +156,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.7.1"
+version = "1.5.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -187,7 +187,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "sql"
-version = "1.19.0"
+version = "1.16.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -213,7 +213,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.8.1"
+version = "2.7.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -255,7 +255,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "java.jdbc"
-version = "1.15.1"
+version = "1.14.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -271,7 +271,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "mysql.cdc.driver"
-version = "1.0.2"
+version = "1.1.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerinax", name = "mysql.driver"}

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -245,11 +245,41 @@ dependencies = [
 	{org = "ballerina", name = "random"},
 	{org = "ballerina", name = "test"},
 	{org = "ballerinai", name = "observe"},
+	{org = "ballerinax", name = "cdc.schema.aws.s3.driver"},
+	{org = "ballerinax", name = "cdc.schema.azure.blob.driver"},
+	{org = "ballerinax", name = "cdc.schema.rocketmq.driver"},
 	{org = "ballerinax", name = "java.jdbc"},
 	{org = "ballerinax", name = "mysql.cdc.driver"}
 ]
 modules = [
 	{org = "ballerinax", packageName = "cdc", moduleName = "cdc"}
+]
+
+[[package]]
+org = "ballerinax"
+name = "cdc.schema.aws.s3.driver"
+version = "1.1.0"
+scope = "testOnly"
+modules = [
+	{org = "ballerinax", packageName = "cdc.schema.aws.s3.driver", moduleName = "cdc.schema.aws.s3.driver"}
+]
+
+[[package]]
+org = "ballerinax"
+name = "cdc.schema.azure.blob.driver"
+version = "1.1.0"
+scope = "testOnly"
+modules = [
+	{org = "ballerinax", packageName = "cdc.schema.azure.blob.driver", moduleName = "cdc.schema.azure.blob.driver"}
+]
+
+[[package]]
+org = "ballerinax"
+name = "cdc.schema.rocketmq.driver"
+version = "1.1.0"
+scope = "testOnly"
+modules = [
+	{org = "ballerinax", packageName = "cdc.schema.rocketmq.driver", moduleName = "cdc.schema.rocketmq.driver"}
 ]
 
 [[package]]

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.13.0"
+distribution-version = "2201.12.0"
 
 [[package]]
 org = "ballerina"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.12.0"
+distribution-version = "2201.13.0"
 
 [[package]]
 org = "ballerina"
@@ -22,7 +22,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "data.jsondata"
-version = "1.1.0"
+version = "1.1.3"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.object"}
@@ -142,7 +142,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.14.0"
+version = "2.17.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -156,7 +156,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.5.1"
+version = "1.7.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -187,7 +187,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "sql"
-version = "1.16.0"
+version = "1.19.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -213,7 +213,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.7.0"
+version = "2.8.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -285,7 +285,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "java.jdbc"
-version = "1.14.0"
+version = "1.15.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,12 +5,12 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.12.0"
+distribution-version = "2201.13.0"
 
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.9.3"
+version = "2.12.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -34,7 +34,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.12.0"
+version = "1.13.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -49,7 +49,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -142,7 +142,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.12.0"
+version = "2.17.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -156,7 +156,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.5.1"
+version = "1.7.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -187,7 +187,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "sql"
-version = "1.16.0"
+version = "1.19.0"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},
@@ -213,7 +213,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -233,7 +233,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "cdc"
-version = "1.3.1"
+version = "1.4.0"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "data.jsondata"},
@@ -255,7 +255,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "java.jdbc"
-version = "1.14.1"
+version = "1.15.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -56,7 +56,7 @@ ballerina {
 configurations.externalJars.resolutionStrategy.eachDependency { details ->
     if (details.requested.group == 'com.fasterxml.jackson.core' ||
             (details.requested.group == 'com.fasterxml.jackson.module' &&
-            details.requested.name == 'jackson-module-afterburner')) {
+            details.requested.name == 'jackson-module-blackbird')) {
         details.useVersion fasterxmlVersion
         details.because 'CVE GHSA-72hv-8253-57qq: force jackson upgrade'
     }
@@ -139,6 +139,18 @@ dependencies {
     externalJars(group: 'org.apache.kafka', name: 'kafka-clients', version: kafkaVersion) {
         transitive false
     }
+    externalJars(group: 'org.apache.maven', name: 'maven-artifact', version: mavenArtifactVersion) {
+        transitive false
+    }
+    externalJars(group: 'org.lz4', name: 'lz4-java', version: lz4Version) {
+        transitive false
+    }
+    externalJars(group: 'org.xerial.snappy', name: 'snappy-java', version: snappyVersion) {
+        transitive false
+    }
+    externalJars(group: 'com.github.luben', name: 'zstd-jni', version: zstdVersion) {
+        transitive false
+    }
 }
 
 tasks.register('updateTomlFiles') {
@@ -147,6 +159,10 @@ tasks.register('updateTomlFiles') {
         newBallerinaToml = newBallerinaToml.replace("@toml.version@", tomlVersion)
         newBallerinaToml = newBallerinaToml.replace("@debezium.version@", debeziumVersion)
         newBallerinaToml = newBallerinaToml.replace("@kafka.version@", kafkaVersion)
+        newBallerinaToml = newBallerinaToml.replace("@maven.artifact.version@", mavenArtifactVersion)
+        newBallerinaToml = newBallerinaToml.replace("@lz4.version@", lz4Version)
+        newBallerinaToml = newBallerinaToml.replace("@snappy.version@", snappyVersion)
+        newBallerinaToml = newBallerinaToml.replace("@zstd.version@", zstdVersion)
         newBallerinaToml = newBallerinaToml.replace("@fasterxml.version@", fasterxmlVersion)
         newBallerinaToml = newBallerinaToml.replace("@jedis.version@", jedisVersion)
         newBallerinaToml = newBallerinaToml.replace("@mutiny.version@", mutinyVersion)

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -54,11 +54,17 @@ ballerina {
 }
 
 configurations.externalJars.resolutionStrategy.eachDependency { details ->
-    if (details.requested.group == 'com.fasterxml.jackson.core' ||
+    if ((details.requested.group == 'com.fasterxml.jackson.core' &&
+            details.requested.name != 'jackson-annotations') ||
             (details.requested.group == 'com.fasterxml.jackson.module' &&
             details.requested.name == 'jackson-module-blackbird')) {
         details.useVersion fasterxmlVersion
         details.because 'CVE GHSA-72hv-8253-57qq: force jackson upgrade'
+    }
+    if (details.requested.group == 'org.eclipse.jetty' ||
+            details.requested.group == 'org.eclipse.jetty.ee10') {
+        details.useVersion jettyVersion
+        details.because 'CVE-2026-10050 and CVE-2026-2332: force Jetty upgrade'
     }
 }
 
@@ -142,7 +148,7 @@ dependencies {
     externalJars(group: 'org.apache.maven', name: 'maven-artifact', version: mavenArtifactVersion) {
         transitive false
     }
-    externalJars(group: 'org.lz4', name: 'lz4-java', version: lz4Version) {
+    externalJars(group: 'at.yawk.lz4', name: 'lz4-java', version: lz4Version) {
         transitive false
     }
     externalJars(group: 'org.xerial.snappy', name: 'snappy-java', version: snappyVersion) {
@@ -164,6 +170,7 @@ tasks.register('updateTomlFiles') {
         newBallerinaToml = newBallerinaToml.replace("@snappy.version@", snappyVersion)
         newBallerinaToml = newBallerinaToml.replace("@zstd.version@", zstdVersion)
         newBallerinaToml = newBallerinaToml.replace("@fasterxml.version@", fasterxmlVersion)
+        newBallerinaToml = newBallerinaToml.replace("@jackson.annotations.version@", jacksonAnnotationsVersion)
         newBallerinaToml = newBallerinaToml.replace("@jedis.version@", jedisVersion)
         newBallerinaToml = newBallerinaToml.replace("@mutiny.version@", mutinyVersion)
         newBallerinaToml = newBallerinaToml.replace("@smallrye.common.version@", smallryeCommonVersion)
@@ -189,46 +196,26 @@ tasks.register('commitTomlFiles') {
     }
 }
 
-tasks.register('startMySQLServer') {
+def testComposeProjectName = 'ballerina-cdc-tests'
+def testComposeFile = 'tests/environment/compose.yaml'
+
+tasks.register('startTestEnvironment') {
     doLast {
-        def stdOut = new ByteArrayOutputStream()
         def cmd = Os.isFamily(Os.FAMILY_WINDOWS) ? ['cmd', '/c'] : ['sh', '-c']
         exec {
-            commandLine cmd + ["docker ps --filter name=mysql-cdc"]
-            standardOutput = stdOut
-        }
-        if (!stdOut.toString().contains("mysql-cdc")) {
-            println "Starting MySQL server."
-            exec {
-                commandLine cmd + ["docker compose -f tests/environment/compose.yaml up -d"]
-                standardOutput = stdOut
-            }
-            println stdOut.toString()
-            sleep(20 * 1000)
-        } else {
-            println "MySQL server is already running."
+            commandLine cmd + ["docker compose -p ${testComposeProjectName} -f ${testComposeFile} " +
+                "up -d --wait mysql azurite minio rocketmq-namesrv rocketmq-broker && " +
+                "docker compose -p ${testComposeProjectName} -f ${testComposeFile} run --rm minio-init && " +
+                "docker compose -p ${testComposeProjectName} -f ${testComposeFile} run --rm rocketmq-init"]
         }
     }
 }
 
-tasks.register('stopMySQLServer') {
+tasks.register('stopTestEnvironment') {
     doLast {
-        def stdOut = new ByteArrayOutputStream()
         def cmd = Os.isFamily(Os.FAMILY_WINDOWS) ? ['cmd', '/c'] : ['sh', '-c']
         exec {
-            commandLine cmd + ["docker ps --filter name=mysql-cdc"]
-            standardOutput = stdOut
-        }
-        if (stdOut.toString().contains("mysql-cdc")) {
-            println "Stopping MySQL server."
-            exec {
-                commandLine cmd + ["docker compose -f tests/environment/compose.yaml rm -svf"]
-                standardOutput = stdOut
-            }
-            println stdOut.toString()
-            sleep(5 * 1000)
-        } else {
-            println "MySQL server is not started."
+            commandLine cmd + ["docker compose -p ${testComposeProjectName} -f ${testComposeFile} down --volumes --remove-orphans"]
         }
     }
 }
@@ -253,8 +240,8 @@ publishing {
 updateTomlFiles.dependsOn copyStdlibs
 build.dependsOn "generatePomFileForMavenPublication"
 
-test.dependsOn "startMySQLServer"
-test.finalizedBy "stopMySQLServer"
+test.dependsOn "startTestEnvironment"
+test.finalizedBy "stopTestEnvironment"
 
 build.dependsOn ":${packageName}-native:build"
 build.dependsOn ":${packageName}-compiler-plugin:build"

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -204,7 +204,7 @@ tasks.register('startTestEnvironment') {
         def cmd = Os.isFamily(Os.FAMILY_WINDOWS) ? ['cmd', '/c'] : ['sh', '-c']
         exec {
             commandLine cmd + ["docker compose -p ${testComposeProjectName} -f ${testComposeFile} " +
-                "up -d --wait mysql azurite minio rocketmq-namesrv rocketmq-broker && " +
+                "up -d --wait --wait-timeout 120 mysql azurite minio rocketmq-namesrv rocketmq-broker && " +
                 "docker compose -p ${testComposeProjectName} -f ${testComposeFile} run --rm minio-init && " +
                 "docker compose -p ${testComposeProjectName} -f ${testComposeFile} run --rm rocketmq-init"]
         }

--- a/ballerina/debezium_properties.bal
+++ b/ballerina/debezium_properties.bal
@@ -93,6 +93,7 @@ const string SCHEMA_HISTORY_INTERNAL_S3_REGION = "schema.history.internal.s3.reg
 const string SCHEMA_HISTORY_INTERNAL_S3_BUCKET_NAME = "schema.history.internal.s3.bucket.name";
 const string SCHEMA_HISTORY_INTERNAL_S3_OBJECT_NAME = "schema.history.internal.s3.object.name";
 const string SCHEMA_HISTORY_INTERNAL_S3_ENDPOINT = "schema.history.internal.s3.endpoint";
+const string SCHEMA_HISTORY_INTERNAL_S3_FORCE_PATH_STYLE = "schema.history.internal.s3.forcePathStyle";
 
 // Azure Blob schema history properties
 const string SCHEMA_HISTORY_INTERNAL_AZURE_STORAGE_CONNECTION_STRING = "schema.history.internal.azure.storage.account.connectionstring";
@@ -102,7 +103,7 @@ const string SCHEMA_HISTORY_INTERNAL_AZURE_STORAGE_BLOB_NAME = "schema.history.i
 
 // RocketMQ schema history properties
 const string SCHEMA_HISTORY_INTERNAL_ROCKETMQ_TOPIC = "schema.history.internal.rocketmq.topic";
-const string SCHEMA_HISTORY_INTERNAL_ROCKETMQ_NAMESRV_ADDR = "schema.history.internal.rocketmq.namesrv.addr";
+const string SCHEMA_HISTORY_INTERNAL_ROCKETMQ_NAMESRV_ADDR = "schema.history.internal.rocketmq.name.srv.addr";
 const string SCHEMA_HISTORY_INTERNAL_ROCKETMQ_ACL_ENABLED = "schema.history.internal.rocketmq.acl.enabled";
 const string SCHEMA_HISTORY_INTERNAL_ROCKETMQ_ACCESS_KEY = "schema.history.internal.rocketmq.access.key";
 const string SCHEMA_HISTORY_INTERNAL_ROCKETMQ_SECRET_KEY = "schema.history.internal.rocketmq.secret.key";
@@ -177,7 +178,7 @@ const string INCREMENTAL_SNAPSHOT_ALLOW_SCHEMA_CHANGES = "incremental.snapshot.a
 
 // Transaction metadata properties
 const string PROVIDE_TRANSACTION_METADATA = "provide.transaction.metadata";
-const string TRANSACTION_TOPIC = "transaction.topic";
+const string TRANSACTION_TOPIC = "topic.transaction";
 
 // Column transformation properties
 const string COLUMN_MASK_HASH_WITH = "column.mask.hash.with";

--- a/ballerina/tests/core_properties_test.bal
+++ b/ballerina/tests/core_properties_test.bal
@@ -26,6 +26,112 @@ final DatabaseConnection databaseConn = {
 };
 
 @test:Config {}
+function testKafkaSchemaHistoryMapsPemSecurityOptions() {
+    InternalSchemaStorage storage = {
+        bootstrapServers: ["broker-1:9092", "broker-2:9092"],
+        securityProtocol: PROTOCOL_SASL_SSL,
+        auth: {mechanism: AUTH_SASL_PLAIN, username: "schema-user", password: "schema-pass"},
+        secureSocket: {
+            cert: "tests/resources/test-cert.pem",
+            key: {
+                certFile: "tests/resources/test-cert.pem",
+                keyFile: "tests/resources/test-key.pem",
+                keyPassword: "key-pass"
+            },
+            ciphers: ["TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384"],
+            protocol: {name: TLS, versions: ["TLSv1.2", "TLSv1.3"]},
+            provider: "SunJSSE"
+        }
+    };
+    map<string> actual = {};
+    populateSchemaHistoryConfigurations(storage, actual);
+
+    test:assertEquals(actual["schema.history.internal.kafka.bootstrap.servers"], "broker-1:9092,broker-2:9092");
+    test:assertEquals(actual["schema.history.internal.producer.sasl.mechanism"], "PLAIN");
+    test:assertEquals(actual["schema.history.internal.consumer.sasl.jaas.config"],
+        "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"schema-user\" password=\"schema-pass\";");
+    test:assertEquals(actual["schema.history.internal.producer.ssl.truststore.type"], "PEM");
+    test:assertEquals(actual["schema.history.internal.consumer.ssl.keystore.type"], "PEM");
+    test:assertEquals(actual["schema.history.internal.producer.ssl.key.password"], "key-pass");
+    test:assertEquals(actual["schema.history.internal.consumer.ssl.cipher.suites"],
+        "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384");
+    test:assertEquals(actual["schema.history.internal.producer.ssl.enabled.protocols"], "TLSv1.2,TLSv1.3");
+    test:assertEquals(actual["schema.history.internal.consumer.ssl.provider"], "SunJSSE");
+}
+
+@test:Config {}
+function testKafkaStorageIgnoresUnreadablePemFiles() {
+    InternalSchemaStorage schemaStorage = {
+        bootstrapServers: "broker:9092",
+        secureSocket: {
+            cert: "tests/resources/test-cert.pem",
+            key: {certFile: "missing-cert.pem", keyFile: "missing-key.pem"}
+        }
+    };
+    map<string> schemaProperties = {};
+    populateSchemaHistoryConfigurations(schemaStorage, schemaProperties);
+    test:assertFalse(schemaProperties.hasKey("schema.history.internal.producer.ssl.keystore.key"));
+
+    OffsetStorage offsetStorage = {
+        bootstrapServers: "broker:9092",
+        secureSocket: {
+            cert: "tests/resources/test-cert.pem",
+            key: {certFile: "missing-cert.pem", keyFile: "missing-key.pem"}
+        }
+    };
+    map<string> offsetProperties = {};
+    populateOffsetStorageConfigurations(offsetStorage, offsetProperties);
+    test:assertFalse(offsetProperties.hasKey("ssl.keystore.key"));
+}
+
+@test:Config {}
+function testKafkaOffsetStorageMapsPemSecurityOptions() {
+    OffsetStorage storage = {
+        bootstrapServers: ["broker-1:9092", "broker-2:9092"],
+        securityProtocol: PROTOCOL_SSL,
+        secureSocket: {
+            cert: "tests/resources/test-cert.pem",
+            key: {
+                certFile: "tests/resources/test-cert.pem",
+                keyFile: "tests/resources/test-key.pem",
+                keyPassword: "offset-key-pass"
+            },
+            ciphers: ["TLS_AES_128_GCM_SHA256"],
+            protocol: {name: TLS, versions: ["TLSv1.3"]},
+            provider: "SunJSSE"
+        }
+    };
+    map<string> actual = {};
+    populateOffsetStorageConfigurations(storage, actual);
+
+    test:assertEquals(actual["bootstrap.servers"], "broker-1:9092,broker-2:9092");
+    test:assertEquals(actual["ssl.truststore.type"], "PEM");
+    test:assertEquals(actual["ssl.keystore.type"], "PEM");
+    test:assertEquals(actual["ssl.key.password"], "offset-key-pass");
+    test:assertEquals(actual["ssl.cipher.suites"], "TLS_AES_128_GCM_SHA256");
+    test:assertEquals(actual["ssl.enabled.protocols"], "TLSv1.3");
+    test:assertEquals(actual["ssl.provider"], "SunJSSE");
+}
+
+@test:Config {}
+function testRelationalFiltersAndMessageKeysMapAllEntries() {
+    map<string> filters = {};
+    populateTableAndColumnConfigurations(["db.orders", "db.customers"], "db.audit", "db.orders.id",
+        ["db.orders.secret", "db.customers.secret"], filters);
+    test:assertEquals(filters["table.include.list"], "db.orders,db.customers");
+    test:assertEquals(filters["table.exclude.list"], "db.audit");
+    test:assertEquals(filters["column.include.list"], "db.orders.id");
+    test:assertEquals(filters["column.exclude.list"], "db.orders.secret,db.customers.secret");
+
+    map<string> keys = {};
+    populateMessageKeyColumnsConfiguration([
+        {tableName: "db.orders", columns: ["tenant_id", "order_id"]},
+        {tableName: "db.customers", columns: ["customer_id"]}
+    ], keys);
+    test:assertEquals(keys["message.key.columns"], "db.orders:tenant_id,order_id;db.customers:customer_id");
+}
+
+@test:Config {}
 function testGetDebeziumProperties() {
     // Expected properties map
     map<string> expectedProperties = {

--- a/ballerina/tests/dynamic_attachment.bal
+++ b/ballerina/tests/dynamic_attachment.bal
@@ -40,6 +40,23 @@ function testStartingWithoutAService() returns error? {
 }
 
 @test:Config {}
+function testStartSurfacesInvalidConnectorFailure() returns error? {
+    MockListener mysqlListener = trackMockListener(new ({
+        database: {
+            username: "testUser",
+            password: "testPassword",
+            connectorClass: "example.invalid.MissingConnector"
+        }
+    }));
+    check mysqlListener.attach(testService);
+    error? result = mysqlListener.'start();
+    test:assertTrue(result is error, "An invalid connector must return a startup error instead of blocking.");
+    if result is error {
+        test:assertTrue(result.message().includes("Failed to start the Debezium engine"));
+    }
+}
+
+@test:Config {}
 function testStopWithoutStart() returns error? {
     MockListener mysqlListener = getDummyMySqlListener();
     error? result = mysqlListener.gracefulStop();

--- a/ballerina/tests/dynamic_attachment.bal
+++ b/ballerina/tests/dynamic_attachment.bal
@@ -94,7 +94,7 @@ function testStartWithServicesWithSameAnnotation() returns error? {
 
 @test:Config {}
 function testAttachAfterStart() returns error? {
-    MockListener mysqlListener = new ({
+    MockListener mysqlListener = trackMockListener(new ({
         database: {
             username,
             password,
@@ -103,7 +103,7 @@ function testAttachAfterStart() returns error? {
         options: {
             snapshotMode: NO_DATA
         }
-    });
+    }));
     check mysqlListener.attach(testService);
     check mysqlListener.'start();
     error? result = mysqlListener.attach(testService);
@@ -115,7 +115,7 @@ function testAttachAfterStart() returns error? {
 @test:Config {
 }
 function testDetachAfterStart() returns error? {
-    MockListener mysqlListener = new ({
+    MockListener mysqlListener = trackMockListener(new ({
         database: {
             username,
             password,
@@ -124,7 +124,7 @@ function testDetachAfterStart() returns error? {
         options: {
             snapshotMode: NO_DATA
         }
-    });
+    }));
 
     check mysqlListener.attach(testService);
     check mysqlListener.'start();
@@ -138,7 +138,7 @@ function testDetachAfterStart() returns error? {
     groups: ["liveness"]
 }
 function testLivenessBeforeListenerStart() returns error? {
-    MockListener mysqlListener = new ({
+    MockListener mysqlListener = trackMockListener(new ({
         database: {
             username,
             password,
@@ -147,7 +147,7 @@ function testLivenessBeforeListenerStart() returns error? {
         options: {
             snapshotMode: NO_DATA
         }
-    });
+    }));
     check mysqlListener.attach(testService);
     boolean liveness = check isLive(mysqlListener);
     test:assertFalse(liveness, "Liveness check passes even before listener starts");
@@ -157,7 +157,7 @@ function testLivenessBeforeListenerStart() returns error? {
     groups: ["liveness"]
 }
 function testLivenessWithStartedListener() returns error? {
-    MockListener mysqlListener = new ({
+    MockListener mysqlListener = trackMockListener(new ({
         database: {
             username,
             password,
@@ -166,7 +166,7 @@ function testLivenessWithStartedListener() returns error? {
         options: {
             snapshotMode: NO_DATA
         }
-    });
+    }));
     check mysqlListener.attach(testService);
     check mysqlListener.'start();
     boolean liveness = check isLive(mysqlListener);
@@ -178,7 +178,7 @@ function testLivenessWithStartedListener() returns error? {
     groups: ["liveness"]
 }
 function testLivenessAfterListenerStop() returns error? {
-    MockListener mysqlListener = new ({
+    MockListener mysqlListener = trackMockListener(new ({
         database: {
             username,
             password,
@@ -187,7 +187,7 @@ function testLivenessAfterListenerStop() returns error? {
         options: {
             snapshotMode: NO_DATA
         }
-    });
+    }));
     check mysqlListener.attach(testService);
     check mysqlListener.'start();
     check mysqlListener.gracefulStop();
@@ -199,7 +199,7 @@ function testLivenessAfterListenerStop() returns error? {
     groups: ["liveness"]
 }
 function testLivenessWithoutReceivingEvents() returns error? {
-    MockListener mysqlListener = new ({
+    MockListener mysqlListener = trackMockListener(new ({
         database: {
             username,
             password,
@@ -209,7 +209,7 @@ function testLivenessWithoutReceivingEvents() returns error? {
             snapshotMode: NO_DATA
         },
         livenessInterval: 5.0
-    });
+    }));
     check mysqlListener.attach(testService);
     check mysqlListener.'start();
     runtime:sleep(10);

--- a/ballerina/tests/environment/compose.yaml
+++ b/ballerina/tests/environment/compose.yaml
@@ -64,11 +64,18 @@ services:
       - "10911:10911"
     volumes:
       - ./rocketmq-broker.conf:/home/rocketmq/rocketmq-5.2.0/conf/broker.conf:ro
+    healthcheck:
+      test: ["CMD-SHELL", "sh mqadmin topicList -n rocketmq-namesrv:9876 >/dev/null 2>&1"]
+      interval: 5s
+      timeout: 30s
+      retries: 12
+      start_period: 30s
 
   rocketmq-init:
     image: apache/rocketmq:5.2.0
     depends_on:
-      - rocketmq-broker
+      rocketmq-broker:
+        condition: service_healthy
     entrypoint: >
       /bin/sh -c "
       for i in $(seq 1 30); do

--- a/ballerina/tests/environment/compose.yaml
+++ b/ballerina/tests/environment/compose.yaml
@@ -34,7 +34,7 @@ services:
       - "9000:9000"
       - "9001:9001"
     healthcheck:
-      test: ["CMD", "curl", "--fail", "http://localhost:9000/minio/health/live"]
+      test: ["CMD", "curl", "--fail", "http://localhost:9000/minio/health/ready"]
       interval: 5s
       timeout: 5s
       retries: 20

--- a/ballerina/tests/environment/compose.yaml
+++ b/ballerina/tests/environment/compose.yaml
@@ -70,4 +70,11 @@ services:
     depends_on:
       - rocketmq-broker
     entrypoint: >
-      /bin/sh -c "until sh mqadmin topicList -n rocketmq-namesrv:9876; do sleep 2; done"
+      /bin/sh -c "
+      for i in $(seq 1 30); do
+        sh mqadmin topicList -n rocketmq-namesrv:9876 && exit 0;
+        sleep 2;
+      done;
+      echo 'rocketmq broker did not become reachable within the timeout' >&2;
+      exit 1
+      "

--- a/ballerina/tests/environment/compose.yaml
+++ b/ballerina/tests/environment/compose.yaml
@@ -1,9 +1,8 @@
-name: cdc-test-cases
+name: ballerina-cdc-tests
 
 services:
   mysql:
     image: mysql:8.0
-    container_name: mysql-cdc
     ports:
       - "3307:3306"
     environment:
@@ -18,3 +17,57 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+
+  azurite:
+    image: mcr.microsoft.com/azure-storage/azurite:3.31.0
+    command: azurite-blob --blobHost 0.0.0.0 --blobPort 10000 --skipApiVersionCheck
+    ports:
+      - "10000:10000"
+
+  minio:
+    image: minio/minio:RELEASE.2024-11-07T00-52-20Z
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    healthcheck:
+      test: ["CMD", "curl", "--fail", "http://localhost:9000/minio/health/live"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  minio-init:
+    image: minio/mc:RELEASE.2024-11-05T11-29-45Z
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "mc alias set local http://minio:9000 minioadmin minioadmin &&
+      mc mb --ignore-existing local/cdc-schema-history"
+
+  rocketmq-namesrv:
+    image: apache/rocketmq:5.2.0
+    command: sh mqnamesrv
+    ports:
+      - "9876:9876"
+
+  rocketmq-broker:
+    image: apache/rocketmq:5.2.0
+    depends_on:
+      - rocketmq-namesrv
+    command: sh mqbroker -n rocketmq-namesrv:9876 -c /home/rocketmq/rocketmq-5.2.0/conf/broker.conf
+    ports:
+      - "10909:10909"
+      - "10911:10911"
+    volumes:
+      - ./rocketmq-broker.conf:/home/rocketmq/rocketmq-5.2.0/conf/broker.conf:ro
+
+  rocketmq-init:
+    image: apache/rocketmq:5.2.0
+    depends_on:
+      - rocketmq-broker
+    entrypoint: >
+      /bin/sh -c "until sh mqadmin topicList -n rocketmq-namesrv:9876; do sleep 2; done"

--- a/ballerina/tests/environment/rocketmq-broker.conf
+++ b/ballerina/tests/environment/rocketmq-broker.conf
@@ -1,0 +1,7 @@
+brokerClusterName=DefaultCluster
+brokerName=broker-a
+brokerId=0
+listenPort=10911
+namesrvAddr=rocketmq-namesrv:9876
+brokerIP1=127.0.0.1
+autoCreateTopicEnable=true

--- a/ballerina/tests/listener_tests.bal
+++ b/ballerina/tests/listener_tests.bal
@@ -70,7 +70,10 @@ int onErrorCount = 0;
 @test:Config {
 }
 function testMockListenerEvents() returns error? {
-    MockListener testListener = new ({
+    _ = check mysqlClient->execute(`DELETE FROM products WHERE id = 1103`);
+    _ = check mysqlClient->execute(`DELETE FROM vendors WHERE id = 201`);
+
+    MockListener testListener = trackMockListener(new ({
         database: {
             username,
             password,
@@ -78,7 +81,7 @@ function testMockListenerEvents() returns error? {
             includedDatabases: database,
             includedTables: ["store_db.products", "store_db.vendors"]
         }
-    });
+    }));
 
     check testListener.attach(mysqlTestService);
     check testListener.attach(mysqlDataBindingFailService);
@@ -116,4 +119,5 @@ function testMockListenerEvents() returns error? {
     test:assertEquals(onErrorCount, 1, msg = "Error count mismatch.");
 
     check testListener.gracefulStop();
+    _ = check mysqlClient->execute(`DELETE FROM vendors WHERE id = 201`);
 }

--- a/ballerina/tests/mock_listener.bal
+++ b/ballerina/tests/mock_listener.bal
@@ -14,6 +14,25 @@
 // specific language governing permissions and limitations
 // under the License.
 import ballerina/random;
+import ballerina/test;
+
+MockListener[] trackedMockListeners = [];
+
+function trackMockListener(MockListener cdcListener) returns MockListener {
+    trackedMockListeners.push(cdcListener);
+    return cdcListener;
+}
+
+@test:AfterEach
+function cleanupTrackedMockListeners() {
+    foreach MockListener cdcListener in trackedMockListeners {
+        ignoreMockListenerCleanupError(cdcListener.immediateStop());
+    }
+    trackedMockListeners = [];
+}
+
+function ignoreMockListenerCleanupError(error? ignoredStopError) {
+}
 
 # Represents a Ballerina CDC MySQL Listener.
 isolated class MockListener {

--- a/ballerina/tests/options_test.bal
+++ b/ballerina/tests/options_test.bal
@@ -16,6 +16,103 @@
 
 import ballerina/test;
 
+@test:Config {groups: ["options-signal"]}
+function testSignalConfigurationMapsAllChannelsAndSecurity() {
+    SignalConfiguration signal = {
+        'source: {dataCollectionTable: "inventory.debezium_signal"},
+        kafka: {
+            topicName: "signals",
+            bootstrapServers: ["broker-1:9092", "broker-2:9092"],
+            groupId: "signal-consumers",
+            securityProtocol: PROTOCOL_SASL_SSL,
+            auth: {mechanism: AUTH_SASL_PLAIN, username: "signal-user", password: "signal-pass"},
+            secureSocket: {
+                cert: "tests/resources/test-cert.pem",
+                key: {
+                    certFile: "tests/resources/test-cert.pem",
+                    keyFile: "tests/resources/test-key.pem",
+                    keyPassword: "signal-key-pass"
+                },
+                ciphers: ["TLS_AES_128_GCM_SHA256"],
+                protocol: {name: TLS, versions: ["TLSv1.3"]},
+                provider: "SunJSSE"
+            },
+            pollTimeout: 2.5
+        },
+        file: {fileName: "/tmp/signals.txt"},
+        jmx: {}
+    };
+    map<string> actual = {};
+    populateSignalConfiguration(signal, actual);
+
+    test:assertEquals(actual["signal.enabled.channels"], "source,kafka,file,jmx");
+    test:assertEquals(actual["signal.data.collection"], "inventory.debezium_signal");
+    test:assertEquals(actual["signal.kafka.bootstrap.servers"], "broker-1:9092,broker-2:9092");
+    test:assertEquals(actual["signal.consumer.security.protocol"], "SASL_SSL");
+    test:assertEquals(actual["signal.consumer.sasl.mechanism"], "PLAIN");
+    test:assertEquals(actual["signal.consumer.ssl.keystore.type"], "PEM");
+    test:assertEquals(actual["signal.consumer.ssl.key.password"], "signal-key-pass");
+    test:assertEquals(actual["signal.consumer.ssl.cipher.suites"], "TLS_AES_128_GCM_SHA256");
+    test:assertEquals(actual["signal.consumer.ssl.enabled.protocols"], "TLSv1.3");
+    test:assertEquals(actual["signal.consumer.ssl.provider"], "SunJSSE");
+    test:assertEquals(actual["signal.kafka.poll.timeout.ms"], "2500");
+}
+
+@test:Config {groups: ["options-signal"]}
+function testSignalConfigurationIgnoresUnreadablePemFiles() {
+    map<string> actual = {};
+    populateSignalConfiguration({
+        kafka: {
+            secureSocket: {
+                cert: "tests/resources/test-cert.pem",
+                key: {certFile: "missing-cert.pem", keyFile: "missing-key.pem"}
+            }
+        }
+    }, actual);
+    test:assertFalse(actual.hasKey("signal.consumer.ssl.keystore.key"));
+}
+
+@test:Config {groups: ["snapshot"]}
+function testSnapshotConfigurationsMapRelationalAndIncrementalOptions() {
+    map<string> extended = {};
+    populateExtendedSnapshotConfiguration({
+        delay: 1.5,
+        fetchSize: 250,
+        maxThreads: 4,
+        includeCollectionList: ["inventory.orders", "inventory.customers"],
+        incrementalConfig: {chunkSize: 500, watermarkingStrategy: INSERT_DELETE, allowSchemaChanges: true}
+    }, extended);
+    test:assertEquals(extended["snapshot.include.collection.list"], "inventory.orders,inventory.customers");
+    test:assertEquals(extended["incremental.snapshot.chunk.size"], "500");
+    test:assertEquals(extended["incremental.snapshot.watermarking.strategy"], "insert_delete");
+    test:assertEquals(extended["incremental.snapshot.allow.schema.changes"], "true");
+
+    map<string> relational = {};
+    populateRelationalExtendedSnapshotConfiguration({
+        lockingMode: MINIMAL,
+        selectStatementOverrides: ["inventory.orders", "inventory.customers"],
+        queryMode: CUSTOM
+    }, relational);
+    test:assertEquals(relational["snapshot.locking.mode"], "minimal");
+    test:assertEquals(relational["snapshot.select.statement.overrides"], "inventory.orders,inventory.customers");
+    test:assertEquals(relational["snapshot.query.mode"], "custom");
+}
+
+@test:Config {groups: ["options-basic"]}
+function testDataTypeErrorAndPerformanceConfigurationsMapOptionalValues() {
+    map<string> actual = {};
+    populateDataTypeConfiguration({binaryHandlingMode: HEX, timePrecisionMode: NANOSECONDS}, actual);
+    populateErrorHandlingConfiguration({maxAttempts: 7, retryInitialDelay: 0.2, retryMaxDelay: 1.5}, actual);
+    populatePerformanceConfiguration({maxQueueSizeInBytes: (), pollInterval: 0.5}, actual);
+    test:assertEquals(actual["binary.handling.mode"], "hex");
+    test:assertEquals(actual["time.precision.mode"], "nanoseconds");
+    test:assertEquals(actual["errors.max.retries"], "7");
+    test:assertEquals(actual["errors.retry.delay.initial.ms"], "200");
+    test:assertEquals(actual["errors.retry.delay.max.ms"], "1500");
+    test:assertEquals(actual["max.queue.size.in.bytes"], "0");
+    test:assertEquals(actual["poll.interval.ms"], "500");
+}
+
 @test:Config {groups: ["options-basic"]}
 function testPopulateOptionsWithDefaults() {
     SampleDBOptions options = {};

--- a/ballerina/tests/options_test.bal
+++ b/ballerina/tests/options_test.bal
@@ -27,6 +27,19 @@ function testPopulateOptionsWithDefaults() {
     test:assertEquals(actualProperties["decimal.handling.mode"], "double");
 }
 
+@test:Config {groups: ["options-basic"]}
+function testPopulateOptionsWithDeprecatedSchemaOnlySnapshotMode() {
+    SampleDBOptions options = {
+        snapshotMode: SCHEMA_ONLY
+    };
+
+    map<string> actualProperties = {};
+    populateAllOptions(options, actualProperties);
+
+    test:assertEquals(actualProperties["snapshot.mode"], "no_data",
+        msg = "Deprecated SCHEMA_ONLY snapshot mode should map to 'no_data' for backward compatibility.");
+}
+
 @test:Config {groups: ["options-heartbeat"]}
 function testPopulateOptionsWithHeartbeat() {
     map<string> expectedProperties = {

--- a/ballerina/tests/options_test.bal
+++ b/ballerina/tests/options_test.bal
@@ -112,7 +112,8 @@ function testPopulateOptionsWithKafkaSignal() {
 @test:Config {groups: ["options-transaction"]}
 function testPopulateOptionsWithTransactionMetadata() {
     map<string> expectedProperties = {
-        "provide.transaction.metadata": "true"
+        "provide.transaction.metadata": "true",
+        "topic.transaction": "transaction"
     };
 
     SampleDBOptions options = {
@@ -125,6 +126,30 @@ function testPopulateOptionsWithTransactionMetadata() {
     test:assertEquals(actualProperties["provide.transaction.metadata"],
         expectedProperties["provide.transaction.metadata"],
         msg = "Transaction metadata does not match.");
+    test:assertEquals(actualProperties["topic.transaction"],
+        expectedProperties["topic.transaction"],
+        msg = "Transaction metadata topic name property key does not match.");
+}
+
+@test:Config {groups: ["options-transaction"]}
+function testPopulateOptionsWithTransactionMetadataCustomTopicName() {
+    map<string> expectedProperties = {
+        "provide.transaction.metadata": "true",
+        "topic.transaction": "txn"
+    };
+
+    SampleDBOptions options = {
+        transactionMetadataConfig: {
+            topicName: "txn"
+        }
+    };
+
+    map<string> actualProperties = {};
+    populateAllOptions(options, actualProperties);
+
+    test:assertEquals(actualProperties["topic.transaction"],
+        expectedProperties["topic.transaction"],
+        msg = "Custom transaction metadata topic name does not match.");
 }
 
 @test:Config {groups: ["options-column"]}

--- a/ballerina/tests/schema_history_integration_test.bal
+++ b/ballerina/tests/schema_history_integration_test.bal
@@ -1,0 +1,152 @@
+// Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/file;
+import ballerina/lang.runtime;
+import ballerina/test;
+import ballerinax/cdc.schema.azure.blob.driver as _;
+import ballerinax/cdc.schema.aws.s3.driver as _;
+import ballerinax/cdc.schema.rocketmq.driver as _;
+
+Service schemaHistoryTestService =
+@ServiceConfig {tables: "store_db.products"}
+service object {
+    remote function onCreate(record {} after, string tableName = "") returns error? {
+        schemaHistoryCreateEventCount += 1;
+    }
+
+    remote function onRead(record {} before, string tableName = "") returns error? {
+        schemaHistoryReadEventCount += 1;
+    }
+};
+
+int schemaHistoryCreateEventCount = 0;
+int schemaHistoryReadEventCount = 0;
+string? activeSchemaHistoryStorageName = ();
+int? activeSchemaHistoryProductId = ();
+
+const int SCHEMA_HISTORY_EVENT_WAIT_ATTEMPTS = 120;
+const decimal SCHEMA_HISTORY_EVENT_POLL_INTERVAL_SECONDS = 0.25;
+
+@test:Config {groups: ["schema-history-integration"], after: cleanupSchemaHistoryTest}
+function testAzureBlobSchemaHistoryRestart() returns error? {
+    check runSchemaHistoryRestartTest({
+        connectionString: "UseDevelopmentStorage=true",
+        containerName: "schema-history",
+        blobName: "azure-schema-history.dat"
+    }, "azure", 3101);
+}
+
+@test:Config {groups: ["schema-history-integration"], after: cleanupSchemaHistoryTest}
+function testS3SchemaHistoryRestart() returns error? {
+    check runSchemaHistoryRestartTest({
+        accessKeyId: "minioadmin",
+        secretAccessKey: "minioadmin",
+        region: "us-east-1",
+        bucketName: "cdc-schema-history",
+        objectName: "s3-schema-history.dat",
+        endpoint: "http://localhost:9000",
+        forcePathStyle: true
+    }, "s3", 3201);
+}
+
+@test:Config {groups: ["schema-history-integration"], after: cleanupSchemaHistoryTest}
+function testRocketMqSchemaHistoryRestart() returns error? {
+    check runSchemaHistoryRestartTest({
+        topicName: "cdc-schema-history",
+        nameServerAddress: "localhost:9876",
+        recoveryAttempts: 10,
+        storeRecordTimeout: 5.0
+    }, "rocketmq", 3301);
+}
+
+function runSchemaHistoryRestartTest(InternalSchemaStorage schemaStorage, string storageName, int productId) returns error? {
+    schemaHistoryCreateEventCount = 0;
+    schemaHistoryReadEventCount = 0;
+    activeSchemaHistoryStorageName = storageName;
+    activeSchemaHistoryProductId = productId;
+    ignoreSchemaHistoryCleanupResult(file:remove(schemaHistoryOffsetFile(storageName)));
+    _ = check mysqlClient->execute(`DELETE FROM products WHERE id = ${productId}`);
+
+    MockListener initialListener = trackMockListener(new (schemaHistoryListenerConfiguration(schemaStorage, storageName)));
+    check initialListener.attach(schemaHistoryTestService);
+    check initialListener.start();
+    check waitForSchemaHistoryEvent(false, storageName);
+    check initialListener.gracefulStop();
+
+    _ = check mysqlClient->execute(
+        `INSERT INTO products (id, name, price, description, vendor_id)
+         VALUES (${productId}, ${storageName}, 1.0, 'Restart verification', 1)`);
+
+    schemaHistoryCreateEventCount = 0;
+    MockListener restartedListener = trackMockListener(new (schemaHistoryListenerConfiguration(schemaStorage, storageName)));
+    check restartedListener.attach(schemaHistoryTestService);
+    check restartedListener.start();
+    check waitForSchemaHistoryEvent(true, storageName);
+    check restartedListener.gracefulStop();
+}
+
+function waitForSchemaHistoryEvent(boolean expectCreateEvent, string storageName) returns error? {
+    int attempts = 0;
+    while attempts < SCHEMA_HISTORY_EVENT_WAIT_ATTEMPTS {
+        if expectCreateEvent ? schemaHistoryCreateEventCount > 0 : schemaHistoryReadEventCount > 0 {
+            return;
+        }
+        runtime:sleep(SCHEMA_HISTORY_EVENT_POLL_INTERVAL_SECONDS);
+        attempts += 1;
+    }
+    return error(expectCreateEvent ? "The listener did not resume from " + storageName + " schema history."
+        : "The initial snapshot was not received for " + storageName + ".");
+}
+
+function cleanupSchemaHistoryTest() {
+    cleanupTrackedMockListeners();
+    if activeSchemaHistoryStorageName is string {
+        string storageName = <string>activeSchemaHistoryStorageName;
+        ignoreSchemaHistoryCleanupResult(file:remove(schemaHistoryOffsetFile(storageName)));
+    }
+    if activeSchemaHistoryProductId is int {
+        int productId = <int>activeSchemaHistoryProductId;
+        var cleanupResult = mysqlClient->execute(`DELETE FROM products WHERE id = ${productId}`);
+        ignoreSchemaHistoryCleanupResult(cleanupResult);
+    }
+    activeSchemaHistoryStorageName = ();
+    activeSchemaHistoryProductId = ();
+}
+
+function ignoreSchemaHistoryCleanupResult(any|error ignoredResult) {
+}
+
+function schemaHistoryListenerConfiguration(InternalSchemaStorage schemaStorage, string storageName)
+        returns MySqlListenerConfiguration {
+    return {
+        engineName: "schema-history-" + storageName,
+        internalSchemaStorage: schemaStorage,
+        offsetStorage: {fileName: schemaHistoryOffsetFile(storageName)},
+        database: {
+            username,
+            password,
+            port,
+            includedDatabases: database,
+            includedTables: ["store_db.products"],
+            databaseServerId: storageName == "azure" ? "9301" : storageName == "s3" ? "9302" : "9303"
+        }
+    };
+}
+
+function schemaHistoryOffsetFile(string storageName) returns string {
+    return "/tmp/" + storageName + "-schema-history-offsets.dat";
+}

--- a/ballerina/tests/storage_test.bal
+++ b/ballerina/tests/storage_test.bal
@@ -17,6 +17,108 @@
 import ballerina/test;
 
 @test:Config {groups: ["schema-history"]}
+function testJdbcSchemaHistoryMapsCustomStatements() {
+    map<string> actual = {};
+    populateSchemaHistoryConfigurations(<JdbcInternalSchemaStorage>{
+        url: "jdbc:mysql://db:3306/history",
+        username: "history-user",
+        password: "history-pass",
+        tableDdl: "CREATE TABLE history",
+        tableSelect: "SELECT * FROM history",
+        tableInsert: "INSERT INTO history VALUES (?, ?)",
+        tableDelete: "DELETE FROM history"
+    }, actual);
+    test:assertEquals(actual["schema.history.internal.jdbc.user"], "history-user");
+    test:assertEquals(actual["schema.history.internal.jdbc.password"], "history-pass");
+    test:assertEquals(actual["schema.history.internal.jdbc.schema.history.table.ddl"], "CREATE TABLE history");
+    test:assertEquals(actual["schema.history.internal.jdbc.schema.history.table.select"], "SELECT * FROM history");
+    test:assertEquals(actual["schema.history.internal.jdbc.schema.history.table.insert"], "INSERT INTO history VALUES (?, ?)");
+    test:assertEquals(actual["schema.history.internal.jdbc.schema.history.table.delete"], "DELETE FROM history");
+}
+
+@test:Config {groups: ["offset-storage"]}
+function testJdbcOffsetStorageMapsCustomStatements() {
+    map<string> actual = {};
+    populateOffsetStorageConfigurations(<JdbcOffsetStorage>{
+        url: "jdbc:mysql://db:3306/offsets",
+        username: "offset-user",
+        password: "offset-pass",
+        tableDdl: "CREATE TABLE offsets",
+        tableSelect: "SELECT * FROM offsets",
+        tableInsert: "INSERT INTO offsets VALUES (?, ?)",
+        tableDelete: "DELETE FROM offsets"
+    }, actual);
+    test:assertEquals(actual["offset.storage.jdbc.user"], "offset-user");
+    test:assertEquals(actual["offset.storage.jdbc.password"], "offset-pass");
+    test:assertEquals(actual["offset.storage.jdbc.offset.table.ddl"], "CREATE TABLE offsets");
+    test:assertEquals(actual["offset.storage.jdbc.offset.table.select"], "SELECT * FROM offsets");
+    test:assertEquals(actual["offset.storage.jdbc.offset.table.insert"], "INSERT INTO offsets VALUES (?, ?)");
+    test:assertEquals(actual["offset.storage.jdbc.offset.table.delete"], "DELETE FROM offsets");
+}
+
+@test:Config {groups: ["schema-history"]}
+function testRedisSchemaHistoryMapsOptionalSecurityAndWaitValues() {
+    map<string> actual = {};
+    populateSchemaHistoryConfigurations(<RedisInternalSchemaStorage>{
+        address: "redis:6379",
+        username: "redis-user",
+        password: "redis-pass",
+        secureSocket: {cert: "ca.pem", verifyHostName: true},
+        waitConfig: {timeout: 2.0, retryDelay: 0.5},
+        clusterEnabled: true
+    }, actual);
+    test:assertEquals(actual["schema.history.internal.redis.user"], "redis-user");
+    test:assertEquals(actual["schema.history.internal.redis.password"], "redis-pass");
+    test:assertEquals(actual["schema.history.internal.redis.ssl.truststore.type"], "PEM");
+    test:assertEquals(actual["schema.history.internal.redis.wait.enabled"], "true");
+    test:assertEquals(actual["schema.history.internal.redis.wait.retry.enabled"], "true");
+    test:assertEquals(actual["schema.history.internal.redis.wait.retry.delay.ms"], "500");
+    test:assertEquals(actual["schema.history.internal.redis.cluster.enabled"], "true");
+}
+
+@test:Config {groups: ["schema-history"]}
+function testRedisSchemaHistoryDisablesSslAndWaitByDefault() {
+    map<string> actual = {};
+    populateSchemaHistoryConfigurations(<RedisInternalSchemaStorage>{address: "redis:6379"}, actual);
+    test:assertEquals(actual["schema.history.internal.redis.ssl.enabled"], "false");
+    test:assertEquals(actual["schema.history.internal.redis.ssl.hostname.verification.enabled"], "false");
+    test:assertEquals(actual["schema.history.internal.redis.wait.enabled"], "false");
+}
+
+@test:Config {groups: ["offset-storage"]}
+function testRedisOffsetStorageMapsOptionalSecurityAndWaitValues() {
+    map<string> actual = {};
+    populateOffsetStorageConfigurations(<RedisOffsetStorage>{
+        address: "redis:6379",
+        username: "offset-user",
+        password: "offset-pass",
+        secureSocket: {
+            cert: "ca.pem",
+            key: {path: "client.jks", password: "key-pass"},
+            verifyHostName: true
+        },
+        waitConfig: {timeout: 2.0},
+        clusterEnabled: true
+    }, actual);
+    test:assertEquals(actual["offset.storage.redis.user"], "offset-user");
+    test:assertEquals(actual["offset.storage.redis.password"], "offset-pass");
+    test:assertEquals(actual["offset.storage.redis.ssl.truststore.type"], "PEM");
+    test:assertEquals(actual["offset.storage.redis.ssl.keystore.type"], "JKS");
+    test:assertEquals(actual["offset.storage.redis.wait.enabled"], "true");
+    test:assertEquals(actual["offset.storage.redis.wait.retry.enabled"], "false");
+    test:assertEquals(actual["offset.storage.redis.cluster.enabled"], "true");
+}
+
+@test:Config {groups: ["offset-storage"]}
+function testRedisOffsetStorageDisablesSslAndWaitByDefault() {
+    map<string> actual = {};
+    populateOffsetStorageConfigurations(<RedisOffsetStorage>{address: "redis:6379"}, actual);
+    test:assertEquals(actual["offset.storage.redis.ssl.enabled"], "false");
+    test:assertEquals(actual["offset.storage.redis.ssl.hostname.verification.enabled"], "false");
+    test:assertEquals(actual["offset.storage.redis.wait.enabled"], "false");
+}
+
+@test:Config {groups: ["schema-history"]}
 function testKafkaSchemaHistoryWithExtendedOptions() {
     map<string> expectedProperties = {
         "schema.history.internal": "io.debezium.storage.kafka.history.KafkaSchemaHistory",

--- a/ballerina/tests/storage_test.bal
+++ b/ballerina/tests/storage_test.bal
@@ -147,6 +147,23 @@ function testS3SchemaHistory() {
 }
 
 @test:Config {groups: ["schema-history"]}
+function testS3SchemaHistoryWithPathStyleEndpoint() {
+    InternalSchemaStorage schemaStorage = {
+        bucketName: "my-bucket",
+        objectName: "schema-history",
+        region: "us-east-1",
+        endpoint: "http://localhost:9000",
+        forcePathStyle: true
+    };
+
+    map<string> actualProperties = {};
+    populateSchemaHistoryConfigurations(schemaStorage, actualProperties);
+
+    test:assertEquals(actualProperties["schema.history.internal.s3.endpoint"], "http://localhost:9000");
+    test:assertEquals(actualProperties["schema.history.internal.s3.forcePathStyle"], "true");
+}
+
+@test:Config {groups: ["schema-history"]}
 function testAzureBlobSchemaHistory() {
     map<string> expectedProperties = {
         "schema.history.internal": "io.debezium.storage.azure.blob.history.AzureBlobSchemaHistory",
@@ -191,6 +208,9 @@ function testRocketMQSchemaHistory() {
     test:assertEquals(actualProperties["schema.history.internal"],
         expectedProperties["schema.history.internal"],
         msg = "RocketMQ schema history does not match.");
+    test:assertEquals(actualProperties["schema.history.internal.rocketmq.name.srv.addr"],
+        expectedProperties["schema.history.internal.rocketmq.name.srv.addr"],
+        msg = "RocketMQ NameServer address does not match.");
 }
 
 @test:Config {groups: ["offset-storage"]}

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -358,7 +358,7 @@ public type RedisInternalSchemaStorage record {|
 |};
 
 # Amazon S3-based schema history storage configuration.
-# Using this storage backend requires importing the `ballerinax/cdc.storage.aws.s3.driver` module.
+# Using this storage backend requires importing the `ballerinax/cdc.schema.aws.s3.driver` module.
 #
 # + className - Fully-qualified class name of the S3 schema history implementation
 # + accessKeyId - AWS access key ID for authentication
@@ -381,7 +381,7 @@ public type AmazonS3InternalSchemaStorage record {|
 |};
 
 # Azure Blob Storage-based schema history storage configuration.
-# Using this storage backend requires importing the `ballerinax/cdc.storage.azure.blob.driver` module.
+# Using this storage backend requires importing the `ballerinax/cdc.schema.azure.blob.driver` module.
 #
 # + className - Fully-qualified class name of the Azure Blob schema history implementation
 # + connectionString - Azure Storage connection string
@@ -398,7 +398,7 @@ public type AzureBlobInternalSchemaStorage record {|
 |};
 
 # RocketMQ-based schema history storage configuration.
-# Using this storage backend requires importing the `ballerinax/cdc.storage.rocketmq.driver` module.
+# Using this storage backend requires importing the `ballerinax/cdc.schema.rocketmq.driver` module.
 #
 # + className - Fully-qualified class name of the RocketMQ schema history implementation
 # + topicName - RocketMQ topic for schema history

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -367,6 +367,7 @@ public type RedisInternalSchemaStorage record {|
 # + bucketName - S3 bucket name for schema history
 # + objectName - S3 object (file) name within the bucket
 # + endpoint - Custom S3-compatible endpoint URL; uses the AWS endpoint if not set
+# + forcePathStyle - Uses path-style S3 URLs, required by local S3-compatible endpoints such as MinIO
 public type AmazonS3InternalSchemaStorage record {|
     *SchemaHistoryInternal;
     string className = "io.debezium.storage.s3.history.S3SchemaHistory";
@@ -376,6 +377,7 @@ public type AmazonS3InternalSchemaStorage record {|
     string bucketName;
     string objectName;
     string endpoint?;
+    boolean forcePathStyle?;
 |};
 
 # Azure Blob Storage-based schema history storage configuration.

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -37,6 +37,9 @@ public enum EventProcessingFailureHandlingMode {
 # + ALWAYS - Take a snapshot on every connector startup.
 # + INITIAL - Take a snapshot only on initial startup, then stream changes.
 # + INITIAL_ONLY - Take a snapshot on initial startup, then stop.
+# + SCHEMA_ONLY - Deprecated: use `NO_DATA`. Debezium removed the "schema_only" mode in 3.3
+#                 (DBZ-8171); this value is retained for backward compatibility and is sent to
+#                 Debezium as "no_data" (its functional equivalent).
 # + NO_DATA - Snapshot the schema only, without emitting READ events for existing rows.
 # + RECOVERY - Take a snapshot to restore lost schema history.
 # + WHEN_NEEDED - Take a snapshot only when offsets are missing or invalid.
@@ -46,6 +49,7 @@ public enum SnapshotMode {
     ALWAYS = "always",
     INITIAL = "initial",
     INITIAL_ONLY = "initial_only",
+    @deprecated
     SCHEMA_ONLY = "schema_only",
     NO_DATA = "no_data",
     RECOVERY = "recovery",

--- a/ballerina/utils.bal
+++ b/ballerina/utils.bal
@@ -883,6 +883,11 @@ public isolated function populateS3SchemaHistoryConfiguration(AmazonS3InternalSc
     if endpoint is string {
         configMap[SCHEMA_HISTORY_INTERNAL_S3_ENDPOINT] = endpoint;
     }
+
+    boolean? forcePathStyle = storage.forcePathStyle;
+    if forcePathStyle is boolean {
+        configMap[SCHEMA_HISTORY_INTERNAL_S3_FORCE_PATH_STYLE] = forcePathStyle.toString();
+    }
 }
 
 # Populates Azure Blob schema history configuration properties.

--- a/ballerina/utils.bal
+++ b/ballerina/utils.bal
@@ -287,7 +287,7 @@ public isolated function populateOptions(Options options, map<string> configMap)
     configMap[MAX_QUEUE_SIZE] = options.maxQueueSize.toString();
     configMap[MAX_BATCH_SIZE] = options.maxBatchSize.toString();
     configMap[EVENT_PROCESSING_FAILURE_HANDLING_MODE] = options.eventProcessingFailureHandlingMode;
-    configMap[SNAPSHOT_MODE] = options.snapshotMode;
+    configMap[SNAPSHOT_MODE] = options.snapshotMode == "schema_only" ? NO_DATA : options.snapshotMode;
     configMap[SKIPPED_OPERATIONS] = string:'join(",", ...options.skippedOperations);
     configMap[SKIP_MESSAGES_WITHOUT_CHANGE] = options.skipMessagesWithoutChange.toString();
     configMap[DECIMAL_HANDLING_MODE] = options.decimalHandlingMode;

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -26,9 +26,6 @@ artifactId = "debezium-api"
 version = "@debezium.version@"
 path = "./lib/debezium-api-@debezium.version@.jar"
 
-# Debezium 3.5 turned debezium-core into a pom-only aggregator (no jar). The classes that
-# used to live inside debezium-core in 3.0.x are now split across the modules below, which
-# are required at runtime.
 [[platform.java21.dependency]]
 groupId = "io.debezium"
 artifactId = "debezium-config"

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -143,7 +143,7 @@ path = "./lib/maven-artifact-@maven.artifact.version@.jar"
 
 # Kafka 4.x compression codecs required at runtime by kafka-clients/connect.
 [[platform.java21.dependency]]
-groupId = "org.lz4"
+groupId = "at.yawk.lz4"
 artifactId = "lz4-java"
 version = "@lz4.version@"
 path = "./lib/lz4-java-@lz4.version@.jar"
@@ -176,8 +176,8 @@ path = "./lib/jackson-module-blackbird-@fasterxml.version@.jar"
 [[platform.java21.dependency]]
 groupId = "com.fasterxml.jackson.core"
 artifactId = "jackson-annotations"
-version = "@fasterxml.version@"
-path = "./lib/jackson-annotations-@fasterxml.version@.jar"
+version = "@jackson.annotations.version@"
+path = "./lib/jackson-annotations-@jackson.annotations.version@.jar"
 
 [[platform.java21.dependency]]
 groupId = "com.fasterxml.jackson.core"

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -26,11 +26,32 @@ artifactId = "debezium-api"
 version = "@debezium.version@"
 path = "./lib/debezium-api-@debezium.version@.jar"
 
+# Debezium 3.5 turned debezium-core into a pom-only aggregator (no jar). The classes that
+# used to live inside debezium-core in 3.0.x are now split across the modules below, which
+# are required at runtime.
 [[platform.java21.dependency]]
 groupId = "io.debezium"
-artifactId = "debezium-core"
+artifactId = "debezium-config"
 version = "@debezium.version@"
-path = "./lib/debezium-core-@debezium.version@.jar"
+path = "./lib/debezium-config-@debezium.version@.jar"
+
+[[platform.java21.dependency]]
+groupId = "io.debezium"
+artifactId = "debezium-util"
+version = "@debezium.version@"
+path = "./lib/debezium-util-@debezium.version@.jar"
+
+[[platform.java21.dependency]]
+groupId = "io.debezium"
+artifactId = "debezium-connector-common"
+version = "@debezium.version@"
+path = "./lib/debezium-connector-common-@debezium.version@.jar"
+
+[[platform.java21.dependency]]
+groupId = "io.debezium"
+artifactId = "debezium-openlineage-api"
+version = "@debezium.version@"
+path = "./lib/debezium-openlineage-api-@debezium.version@.jar"
 
 [[platform.java21.dependency]]
 groupId = "io.debezium"
@@ -116,17 +137,44 @@ artifactId = "connect-runtime"
 version = "@kafka.version@"
 path = "./lib/connect-runtime-@kafka.version@.jar"
 
+# Required at runtime by connect-runtime for connector version comparison (ComparableVersion).
+[[platform.java21.dependency]]
+groupId = "org.apache.maven"
+artifactId = "maven-artifact"
+version = "@maven.artifact.version@"
+path = "./lib/maven-artifact-@maven.artifact.version@.jar"
+
+# Kafka 4.x compression codecs required at runtime by kafka-clients/connect.
+[[platform.java21.dependency]]
+groupId = "org.lz4"
+artifactId = "lz4-java"
+version = "@lz4.version@"
+path = "./lib/lz4-java-@lz4.version@.jar"
+
+[[platform.java21.dependency]]
+groupId = "org.xerial.snappy"
+artifactId = "snappy-java"
+version = "@snappy.version@"
+path = "./lib/snappy-java-@snappy.version@.jar"
+
+[[platform.java21.dependency]]
+groupId = "com.github.luben"
+artifactId = "zstd-jni"
+version = "@zstd.version@"
+path = "./lib/zstd-jni-@zstd.version@.jar"
+
 [[platform.java21.dependency]]
 groupId = "com.fasterxml.jackson.core"
 artifactId = "jackson-core"
 version = "@fasterxml.version@"
 path = "./lib/jackson-core-@fasterxml.version@.jar"
 
+# Debezium/Jackson 2.19 replaced the deprecated afterburner module with blackbird.
 [[platform.java21.dependency]]
 groupId = "com.fasterxml.jackson.module"
-artifactId = "jackson-module-afterburner"
+artifactId = "jackson-module-blackbird"
 version = "@fasterxml.version@"
-path = "./lib/jackson-module-afterburner-@fasterxml.version@.jar"
+path = "./lib/jackson-module-blackbird-@fasterxml.version@.jar"
 
 [[platform.java21.dependency]]
 groupId = "com.fasterxml.jackson.core"

--- a/build.gradle
+++ b/build.gradle
@@ -93,6 +93,9 @@ subprojects {
 
         ballerinaStdLibs "io.ballerina.lib:mysql.cdc.driver-ballerina:${stdlibMysqlCdcDriverVersion}"
         ballerinaStdLibs "io.ballerina.stdlib:mysql.driver-ballerina:${stdlibMysqlDriverVersion}"
+        ballerinaStdLibs "io.ballerina.lib:cdc.schema.azure.blob.driver-ballerina:${stdlibCdcSchemaAzureBlobDriverVersion}"
+        ballerinaStdLibs "io.ballerina.lib:cdc.schema.aws.s3.driver-ballerina:${stdlibCdcSchemaAwsS3DriverVersion}"
+        ballerinaStdLibs "io.ballerina.lib:cdc.schema.rocketmq.driver-ballerina:${stdlibCdcSchemaRocketmqDriverVersion}"
 
         ballerinaStdLibs "io.ballerina.stdlib:observe-ballerina:${observeVersion}"
         ballerinaStdLibs "io.ballerina:observe-ballerina:${observeInternalVersion}"

--- a/changelog.md
+++ b/changelog.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Upgraded the embedded Debezium runtime to 3.5.1.Final.
 - Fixed `Listener.start()` to surface Debezium engine startup failures immediately instead of hanging forever.
-- Fixed `Listener.gracefulStop()` to wait for the executor to actually terminate instead of returning immediately.
+- Fixed `Listener.gracefulStop()` to wait (bounded by a timeout, escalating to a forced shutdown) for the executor to actually terminate instead of returning immediately, and to report an error rather than discard the executor if it still hasn't terminated.
 
 ### Deprecated
 - Deprecated the `SCHEMA_ONLY` snapshot mode in favor of `NO_DATA` (Debezium removed `schema_only` in 3.3 / DBZ-8171); `SCHEMA_ONLY` is still accepted and mapped to `no_data`.

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,16 @@ This file contains all the notable changes done to the Ballerina `cdc` package t
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Upgraded the embedded Debezium runtime to 3.5.1.Final.
+- Fixed `Listener.start()` to surface Debezium engine startup failures immediately instead of hanging forever.
+- Fixed `Listener.gracefulStop()` to wait for the executor to actually terminate instead of returning immediately.
+
+### Deprecated
+- Deprecated the `SCHEMA_ONLY` snapshot mode in favor of `NO_DATA` (Debezium removed `schema_only` in 3.3 / DBZ-8171); `SCHEMA_ONLY` is still accepted and mapped to `no_data`.
+
 ## [1.3.2]
 
 ### Changed

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina.lib
-version=1.3.2-SNAPSHOT
+version=1.4.0-SNAPSHOT
 
 checkstylePluginVersion=10.12.0
 spotbugsPluginVersion=6.0.18
@@ -10,17 +10,24 @@ releasePluginVersion=2.8.0
 ballerinaGradlePluginVersion=2.3.1
 testngVersion=7.6.1
 
-debeziumVersion=3.0.8.Final
-kafkaVersion=3.9.2
+debeziumVersion=3.5.1.Final
+kafkaVersion=4.1.1
+mavenArtifactVersion=3.9.6
+
+# Compression codecs required at runtime by kafka-clients/connect 4.x.
+lz4Version=1.8.0
+snappyVersion=1.1.10.7
+zstdVersion=1.5.6-10
+
 # This ver should be the one packed with debezium
-fasterxmlVersion=2.18.6
+fasterxmlVersion=2.19.0
 gsonVersion=2.10.1
 
 # Redis storage dependencies
-jedisVersion=4.1.1
-mutinyVersion=2.6.2
-smallryeCommonVersion=2.5.0
-commonsPool2Version=2.11.1
+jedisVersion=6.0.0
+mutinyVersion=2.9.5
+smallryeCommonVersion=2.13.9
+commonsPool2Version=2.12.1
 jctoolsVersion=4.0.5
 
 ballerinaLangVersion=2201.12.0
@@ -44,5 +51,5 @@ observeVersion=1.5.0
 observeInternalVersion=1.5.0
 
 # Ballerina library
-stdlibMysqlCdcDriverVersion=1.0.1
+stdlibMysqlCdcDriverVersion=1.1.0
 stdlibMysqlDriverVersion=1.8.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,16 +11,18 @@ ballerinaGradlePluginVersion=2.3.1
 testngVersion=7.6.1
 
 debeziumVersion=3.5.1.Final
-kafkaVersion=4.1.1
+kafkaVersion=4.1.2
 mavenArtifactVersion=3.9.6
 
 # Compression codecs required at runtime by kafka-clients/connect 4.x.
-lz4Version=1.8.0
+lz4Version=1.10.1
 snappyVersion=1.1.10.7
 zstdVersion=1.5.6-10
 
 # This ver should be the one packed with debezium
-fasterxmlVersion=2.19.0
+fasterxmlVersion=2.21.4
+jacksonAnnotationsVersion=2.21
+jettyVersion=12.0.36
 gsonVersion=2.10.1
 
 # Redis storage dependencies
@@ -53,3 +55,6 @@ observeInternalVersion=1.5.0
 # Ballerina library
 stdlibMysqlCdcDriverVersion=1.1.0
 stdlibMysqlDriverVersion=1.8.0
+stdlibCdcSchemaAzureBlobDriverVersion=1.1.0
+stdlibCdcSchemaAwsS3DriverVersion=1.1.0
+stdlibCdcSchemaRocketmqDriverVersion=1.1.0

--- a/native/src/main/java/io/ballerina/lib/cdc/CdcCompletionCallback.java
+++ b/native/src/main/java/io/ballerina/lib/cdc/CdcCompletionCallback.java
@@ -22,6 +22,7 @@ import io.debezium.engine.DebeziumEngine;
 
 import java.io.PrintStream;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -31,6 +32,22 @@ public class CdcCompletionCallback implements DebeziumEngine.CompletionCallback 
     private static final PrintStream ERR_OUT = System.err;
 
     private final AtomicBoolean invoked = new AtomicBoolean(false);
+    private final CompletableFuture<?> startupFuture;
+
+    public CdcCompletionCallback() {
+        this(null);
+    }
+
+    /**
+     * @param startupFuture the future awaited by the engine starter. If the engine terminates with a
+     *                      failure before it ever started (so {@code taskStarted()} never completes the
+     *                      future), this callback completes it exceptionally so the starter surfaces a
+     *                      clean error instead of blocking forever. Once the engine has started the
+     *                      future is already completed, so a later failure here is a no-op for it.
+     */
+    public CdcCompletionCallback(CompletableFuture<?> startupFuture) {
+        this.startupFuture = startupFuture;
+    }
 
     @Override
     public void handle(boolean success, String message, Throwable error) {
@@ -44,6 +61,10 @@ public class CdcCompletionCallback implements DebeziumEngine.CompletionCallback 
             errorMsg = errorMsg + ": " + error.getMessage();
         }
         ERR_OUT.println(errorMsg);
+
+        if (startupFuture != null && !startupFuture.isDone()) {
+            startupFuture.completeExceptionally(new IllegalStateException(errorMsg, error));
+        }
     }
 
     public boolean isInvoked() {

--- a/native/src/main/java/io/ballerina/lib/cdc/Listener.java
+++ b/native/src/main/java/io/ballerina/lib/cdc/Listener.java
@@ -47,8 +47,10 @@ import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 
 import static io.ballerina.lib.cdc.utils.Constants.ANN_CONFIG_TABLES;
@@ -70,6 +72,7 @@ public class Listener {
     private static final String LISTENER_START_TIME_KEY = "ListenerStartTime";
     private static final BString LIVENESS_INTERVAL_CONFIG_KEY = StringUtils.fromString("livenessInterval");
     private static final long DEFAULT_LIVENESS_INTERVAL_MILLIS = 60000;
+    private static final long EXECUTOR_SHUTDOWN_TIMEOUT_MILLIS = 60000;
 
     public static final String TABLE_TO_SERVICE_MAP_KEY = "TABLE_TO_SERVICE_MAP";
     public static final String DEBEZIUM_ENGINE_KEY = "DEB_ENGINE";
@@ -237,7 +240,7 @@ public class Listener {
                 .getNativeData(TABLE_TO_SERVICE_MAP_KEY);
 
         CompletableFuture<EngineResult> comFuture = new CompletableFuture<>();
-        CdcCompletionCallback completionCallback = new CdcCompletionCallback();
+        CdcCompletionCallback completionCallback = new CdcCompletionCallback(comFuture);
         BalChangeConsumer changeConsumer = new BalChangeConsumer(serviceMap, environment.getRuntime());
         ExecutorService executor = Executors.newVirtualThreadPerTaskExecutor();
         DebeziumEngine<ChangeEvent<String, String>> engine = create(Json.class)
@@ -255,7 +258,15 @@ public class Listener {
                 .build();
         executor.submit(engine);
 
-        EngineResult engineResult = comFuture.get();
+        EngineResult engineResult;
+        try {
+            engineResult = comFuture.get();
+        } catch (ExecutionException e) {
+            executor.shutdownNow();
+            Throwable cause = e.getCause();
+            return createCdcError("Failed to start the Debezium engine: "
+                    + (cause != null ? cause.getMessage() : e.getMessage()));
+        }
         if (engineResult.success) {
             listener.addNativeData(DEBEZIUM_ENGINE_KEY, engine);
             listener.addNativeData(EXECUTOR_SERVICE_KEY, executor);
@@ -264,6 +275,7 @@ public class Listener {
             listener.addNativeData(LIVENESS_INTERVAL_KEY, livenessInterval);
             listener.addNativeData(LISTENER_START_TIME_KEY, Instant.now());
         } else {
+            executor.shutdownNow();
             return createCdcError("Failed to start the Debezium engine due to unknown error");
         }
         listener.addNativeData(IS_STARTED_KEY, true);
@@ -284,7 +296,13 @@ public class Listener {
 
             Object executor = listener.getNativeData(EXECUTOR_SERVICE_KEY);
             if (executor != null) {
-                ((ExecutorService) executor).shutdown();
+                ExecutorService executorService = (ExecutorService) executor;
+                executorService.shutdown();
+                try {
+                    executorService.awaitTermination(EXECUTOR_SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
                 listener.addNativeData(EXECUTOR_SERVICE_KEY, null);
             }
 

--- a/native/src/main/java/io/ballerina/lib/cdc/Listener.java
+++ b/native/src/main/java/io/ballerina/lib/cdc/Listener.java
@@ -248,7 +248,7 @@ public class Listener {
                 .notifying(changeConsumer)
                 .using(new DebeziumEngine.ConnectorCallback() {
                     @Override
-                    public void taskStarted() {
+                    public void pollingStarted() {
                         EngineResult result = new EngineResult();
                         result.success = true;
                         comFuture.complete(result);
@@ -261,6 +261,10 @@ public class Listener {
         EngineResult engineResult;
         try {
             engineResult = comFuture.get();
+        } catch (InterruptedException e) {
+            executor.shutdownNow();
+            Thread.currentThread().interrupt();
+            return createCdcError("Failed to start the Debezium engine: " + e.getMessage());
         } catch (ExecutionException e) {
             executor.shutdownNow();
             Throwable cause = e.getCause();

--- a/native/src/main/java/io/ballerina/lib/cdc/Listener.java
+++ b/native/src/main/java/io/ballerina/lib/cdc/Listener.java
@@ -298,24 +298,39 @@ public class Listener {
                 listener.addNativeData(DEBEZIUM_ENGINE_KEY, null);
             }
 
+            Object terminationError = null;
             Object executor = listener.getNativeData(EXECUTOR_SERVICE_KEY);
             if (executor != null) {
                 ExecutorService executorService = (ExecutorService) executor;
                 executorService.shutdown();
-                try {
-                    executorService.awaitTermination(EXECUTOR_SHUTDOWN_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
+                boolean terminated = awaitTermination(executorService, EXECUTOR_SHUTDOWN_TIMEOUT_MILLIS);
+                if (!terminated) {
+                    executorService.shutdownNow();
+                    terminated = awaitTermination(executorService, EXECUTOR_SHUTDOWN_TIMEOUT_MILLIS);
                 }
-                listener.addNativeData(EXECUTOR_SERVICE_KEY, null);
+                if (terminated) {
+                    listener.addNativeData(EXECUTOR_SERVICE_KEY, null);
+                } else {
+                    terminationError = createCdcError(
+                            "Failed to stop the Debezium engine: executor did not terminate within the timeout");
+                }
             }
 
             listener.addNativeData(IS_STARTED_KEY, false);
-            return null;
+            return terminationError;
         } catch (IOException e) {
             return createCdcError("Failed to stop the Debezium engine: " + e.getMessage());
         } finally {
             lock.unlock();
+        }
+    }
+
+    private static boolean awaitTermination(ExecutorService executorService, long timeoutMillis) {
+        try {
+            return executorService.awaitTermination(timeoutMillis, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            return false;
         }
     }
 


### PR DESCRIPTION
## Summary
- Bumps the embedded Debezium runtime from 3.0.8.Final to 3.5.1.Final (needed for Oracle AI Database 26ai support — Debezium 3.5 resolves the DB version via JDBC driver metadata instead of parsing the `BANNER_FULL` string, which broke on 26ai's rebranded banner).
- Debezium 3.5 turned `debezium-core` into a pom-only aggregator; bundles the now-required `debezium-config`/`debezium-util`/`debezium-connector-common`/`debezium-openlineage-api`/`debezium-embedded` jars, plus Kafka Connect 4.x runtime deps (`maven-artifact`, `lz4-java`, `snappy-java`, `zstd-jni`) that used to come along transitively.
- `Listener.start()`: surfaces Debezium engine startup failures immediately instead of hanging forever — `CdcCompletionCallback` now completes the startup future exceptionally on a failed start, and `start()` unwraps/reports that error instead of blocking on `comFuture.get()` with no way to fail.
- `Listener.gracefulStop()`: waits (bounded by a timeout) for the executor to actually terminate instead of firing `shutdown()` and returning immediately.
- Deprecates `SnapshotMode.SCHEMA_ONLY` in favor of `NO_DATA` (Debezium removed `schema_only` in 3.3 / DBZ-8171); still accepted and mapped to `no_data` for backward compatibility.

## Test plan
- [x] `./gradlew :cdc-native:build :cdc-ballerina:build` — BUILD SUCCESSFUL (checkstyle/spotbugs included).
- [x] Verified `testCdcListenerEvents`/`testDetachAfterStart`/`testAttachAfterStart` pass against real MySQL, SQL Server, and PostgreSQL containers with this cdc version plus the corresponding `*.cdc.driver` bumps.
- [x] Verified end-to-end against a real Oracle AI Database 26ai instance — full INSERT/UPDATE/DELETE CDC event flow confirmed, no `Failed to resolve Oracle database version` error.

**Note:** `cdc-examples` currently fails to build against this branch because it depends on `ballerinax/mysql.cdc.driver` 1.1.0, which isn't published to Ballerina Central yet ([mysql.cdc.driver#10](https://github.com/ballerina-platform/module-ballerinax-mysql.cdc.driver/pull/10) is still a draft). This PR should be merged once that release (and the other `*.cdc.driver` bumps it depends on for full verification) are out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Upgraded the embedded Debezium runtime to 3.5.1.Final and advanced Kafka dependencies to 4.x, adding the additional Debezium connector/runtime modules required after `debezium-core` became a POM-only aggregator.
- Extended CDC support for Oracle AI Database 26ai via JDBC metadata-based version resolution.
- Improved CDC listener lifecycle handling by surfacing Debezium engine startup failures immediately, ensuring graceful shutdown waits for executor termination (bounded by a timeout), and handling interruption during startup/shutdown more reliably.
- Deprecated `SnapshotMode.SCHEMA_ONLY` in favor of `NO_DATA` while keeping backward compatibility by mapping `SCHEMA_ONLY` to `no_data`, with a regression test to verify the behavior.
- Added/adjusted schema-history and related configuration support (including S3 path-style endpoint options, RocketMQ schema-history property corrections, and transaction topic metadata mapping), plus new constants and option-mapping coverage.
- Expanded integration and unit test coverage for schema-history recovery across S3, Azure Blob, and RocketMQ, and refactored the test Docker Compose environment setup/teardown with a more comprehensive service stack and improved cleanup to prevent test hangs or leakage.
- Updated release/build configuration and dependency metadata for the 1.4.0-SNAPSHOT/1.4.0 line (including Gradle TOML updates and dependency version enforcement) to keep CI dependency resolution stable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->