### PR TITLE
Fix CDC packaged dependency vulnerabilities

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -145,8 +145,8 @@ path = "./lib/maven-artifact-3.9.6.jar"
 [[platform.java21.dependency]]
 groupId = "at.yawk.lz4"
 artifactId = "lz4-java"
-version = "1.10.1"
-path = "./lib/lz4-java-1.10.1.jar"
+version = "1.11.1"
+path = "./lib/lz4-java-1.11.1.jar"
 
 [[platform.java21.dependency]]
 groupId = "org.xerial.snappy"
@@ -163,15 +163,15 @@ path = "./lib/zstd-jni-1.5.6-10.jar"
 [[platform.java21.dependency]]
 groupId = "com.fasterxml.jackson.core"
 artifactId = "jackson-core"
-version = "2.21.4"
-path = "./lib/jackson-core-2.21.4.jar"
+version = "2.21.5"
+path = "./lib/jackson-core-2.21.5.jar"
 
 # Debezium/Jackson 2.19 replaced the deprecated afterburner module with blackbird.
 [[platform.java21.dependency]]
 groupId = "com.fasterxml.jackson.module"
 artifactId = "jackson-module-blackbird"
-version = "2.21.4"
-path = "./lib/jackson-module-blackbird-2.21.4.jar"
+version = "2.21.5"
+path = "./lib/jackson-module-blackbird-2.21.5.jar"
 
 [[platform.java21.dependency]]
 groupId = "com.fasterxml.jackson.core"
@@ -182,5 +182,5 @@ path = "./lib/jackson-annotations-2.21.jar"
 [[platform.java21.dependency]]
 groupId = "com.fasterxml.jackson.core"
 artifactId = "jackson-databind"
-version = "2.21.4"
-path = "./lib/jackson-databind-2.21.4.jar"
+version = "2.21.5"
+path = "./lib/jackson-databind-2.21.5.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -22,7 +22,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "data.jsondata"
-version = "1.1.0"
+version = "1.1.4"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.object"}
@@ -285,7 +285,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "java.jdbc"
-version = "1.14.0"
+version = "1.14.1"
 scope = "testOnly"
 dependencies = [
 	{org = "ballerina", name = "io"},

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -53,21 +53,6 @@ ballerina {
     testCoverageParam = "--code-coverage --coverage-format=xml --includes=io.ballerina.lib.cdc.*:ballerinax.cdc.*"
 }
 
-configurations.externalJars.resolutionStrategy.eachDependency { details ->
-    if ((details.requested.group == 'com.fasterxml.jackson.core' &&
-            details.requested.name != 'jackson-annotations') ||
-            (details.requested.group == 'com.fasterxml.jackson.module' &&
-            details.requested.name == 'jackson-module-blackbird')) {
-        details.useVersion fasterxmlVersion
-        details.because 'CVE GHSA-72hv-8253-57qq: force jackson upgrade'
-    }
-    if (details.requested.group == 'org.eclipse.jetty' ||
-            details.requested.group == 'org.eclipse.jetty.ee10') {
-        details.useVersion jettyVersion
-        details.because 'CVE-2026-10050 and CVE-2026-2332: force Jetty upgrade'
-    }
-}
-
 dependencies {
 
     externalJars(group: 'io.debezium', name: 'debezium-embedded', version: debeziumVersion) {
@@ -77,6 +62,7 @@ dependencies {
         // Packed separately
         exclude group: 'io.debezium', module: 'debezium-api'
         exclude group: 'com.fasterxml.jackson.datatype', module: 'jackson-datatype-jsr310'
+        exclude group: 'com.fasterxml.jackson.core'
     }
     externalJars(group: 'io.debezium', name: 'debezium-api', version: debeziumVersion) {
         transitive false
@@ -110,6 +96,18 @@ dependencies {
     externalJars(group: 'org.jctools', name: 'jctools-core', version: jctoolsVersion) {
         transitive false
     }
+    externalJars(group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: fasterxmlVersion) {
+        transitive false
+    }
+    externalJars(group: 'com.fasterxml.jackson.core', name: 'jackson-annotations', version: jacksonAnnotationsVersion) {
+        transitive false
+    }
+    externalJars(group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: fasterxmlVersion) {
+        transitive false
+    }
+    externalJars(group: 'com.fasterxml.jackson.module', name: 'jackson-module-blackbird', version: fasterxmlVersion) {
+        transitive false
+    }
 
     externalJars(group: 'org.apache.kafka', name: 'connect-runtime', version: kafkaVersion) {
         exclude group: 'org.slf4j', module: 'slf4j-api'
@@ -120,10 +118,9 @@ dependencies {
         exclude group: 'org.glassfish.jersey.inject', module: 'jersey-hk2'
         exclude group: 'javax.xml.bind', module: 'jaxb-api'
         exclude group: 'javax.activation', module: 'activation'
-        exclude group: 'org.eclipse.jetty', module: 'jetty-server'
-        exclude group: 'org.eclipse.jetty', module: 'jetty-servlet'
-        exclude group: 'org.eclipse.jetty', module: 'jetty-servlets'
-        exclude group: 'org.eclipse.jetty', module: 'jetty-client' // Duplicate removed
+        exclude group: 'org.eclipse.jetty'
+        exclude group: 'org.eclipse.jetty.ee10'
+        exclude group: 'com.fasterxml.jackson.core'
         exclude group: 'org.reflections', module: 'reflections'
         exclude group: 'org.apache.maven', module: 'maven-artifact'
         exclude group: 'io.swagger.core.v3', module: 'swagger-annotations'
@@ -140,7 +137,9 @@ dependencies {
     externalJars(group: 'org.apache.kafka', name: 'connect-json', version: kafkaVersion) {
         exclude group: 'org.slf4j', module: 'slf4j-api'
         exclude group: 'org.apache.kafka', module: 'connect-api'
+        exclude group: 'com.fasterxml.jackson.core'
         exclude group: 'com.fasterxml.jackson.datatype', module: 'jackson-datatype-jdk8'
+        exclude group: 'com.fasterxml.jackson.module', module: 'jackson-module-blackbird'
     }
     externalJars(group: 'org.apache.kafka', name: 'kafka-clients', version: kafkaVersion) {
         transitive false

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,14 +15,13 @@ kafkaVersion=4.1.2
 mavenArtifactVersion=3.9.6
 
 # Compression codecs required at runtime by kafka-clients/connect 4.x.
-lz4Version=1.10.1
+lz4Version=1.11.1
 snappyVersion=1.1.10.7
 zstdVersion=1.5.6-10
 
 # This ver should be the one packed with debezium
-fasterxmlVersion=2.21.4
+fasterxmlVersion=2.21.5
 jacksonAnnotationsVersion=2.21
-jettyVersion=12.0.36
 gsonVersion=2.10.1
 
 # Redis storage dependencies


### PR DESCRIPTION
## Summary

- Remove Gradle resolution-strategy overrides for Jackson and Jetty.
- Package the required Jackson artifacts directly and exclude redundant Kafka Connect transitive artifacts.
- Upgrade LZ4 and Jackson packaged dependencies to their fixed releases.

## Validation

- `./gradlew clean build -x :cdc-ballerina:commitTomlFiles`
- `trivy rootfs --scanners vuln --format table --exit-code 1 ballerina/lib`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Updated packaged LZ4 and Jackson dependencies to fixed releases.
- Removed Gradle resolution overrides for Jackson and Jetty, replacing them with explicit Jackson dependencies.
- Excluded redundant Kafka Connect transitive artifacts.
- Refreshed related Ballerina package versions.
- Validation included a clean Gradle build and Trivy scan of `ballerina/lib`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->